### PR TITLE
Hooks

### DIFF
--- a/CommandDotNet.Tests/CustomIoCTests.cs
+++ b/CommandDotNet.Tests/CustomIoCTests.cs
@@ -1,12 +1,96 @@
 ﻿using System;
 using Autofac;
 using CommandDotNet.Attributes;
+using CommandDotNet.CommandInvoker;
+using CommandDotNet.Models;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace CommandDotNet.Tests
 {
+    public class PrePostHookTests : TestBase
+    {
+        public PrePostHookTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public void BothHooksFire()
+        {
+            var appRunner = new AppRunner<PrePostHookApp>(new AppSettings{EnableCommandHooks = true});
+                
+            appRunner.Run("Get", "--pre", "3", "--post", "5").Should().Be(0);
+            
+            Assert.True(PrePostHookApp.GetResults().PostHookFired);
+        }
+        
+        [Fact]
+        public void OptionArgumentsAreNotRequired()
+        {
+            var appRunner = new AppRunner<PrePostHookApp>(new AppSettings{EnableCommandHooks = true});
+                
+            appRunner.Run("Get", "--pre", "3", "--post", "5", "-o", "10").Should().Be(0);
+            
+            Assert.True(PrePostHookApp.GetResults().PostHookFired);
+        }
+
+        public class Results
+        {
+            public bool PreHookFired = false;
+            public bool PostHookFired = false;
+        }
+        public class PrePostHookApp
+        {
+            private static Results _results = new Results();
+
+            public static Results GetResults()
+            {
+                var results = _results;
+                _results = new Results();
+                return results;
+            }
+            
+            [PreHook]
+            public void PreHook(PreHookModel preHookModel)
+            {
+                Assert.NotNull(preHookModel);
+                _results.PreHookFired = true;
+            }
+            
+            [PostHook]
+            public void PostHook(PostHookModel postHookModel, OptionalModel optionalModel)
+            {
+                Assert.NotNull(postHookModel);
+                _results.PostHookFired = true;
+            }
+        
+            public void Get(PreHookModel preHookModel, PostHookModel postHookModel, OptionalModel commonHookModel)
+            {
+                Assert.True(_results.PreHookFired);
+                Assert.False(_results.PostHookFired);
+            }
+        }
+        
+        public class PreHookModel : IArgumentModel
+        {
+            [Option(LongName = "pre")]
+            public int Value { get; set; }
+        }
+        
+        public class PostHookModel : IArgumentModel
+        {
+            [Option(LongName = "post")]
+            public int Value { get; set; }
+        }
+        
+        public class OptionalModel : IArgumentModel
+        {
+            [Option(ShortName = "o")]
+            public int Value { get; set; }
+        }
+    }
+    
     public class CustomIoCTests : TestBase
     {
         public CustomIoCTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)

--- a/CommandDotNet/CommandInvoker/PrePostHookCommandInvoker.cs
+++ b/CommandDotNet/CommandInvoker/PrePostHookCommandInvoker.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using CommandDotNet.Extensions;
+
+namespace CommandDotNet.CommandInvoker
+{
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class PreHookAttribute : Attribute
+    {
+        
+    }
+    
+    [AttributeUsage(AttributeTargets.Property)]
+    public class PostHookAttribute : Attribute
+    {
+        
+    }
+    
+    internal class PrePostHookCommandInvoker : ICommandInvoker
+    {
+        private readonly ICommandInvoker _commandInvoker;
+
+        public PrePostHookCommandInvoker(ICommandInvoker commandInvoker)
+        {
+            this._commandInvoker = commandInvoker;
+        }
+
+        public object Invoke(CommandInvocation commandInvocation)
+        {
+            var type = commandInvocation.Instance.GetType();
+
+
+            try
+            {
+                ExecuteHooks<PreHookAttribute>(type, commandInvocation);
+                return this._commandInvoker.Invoke(commandInvocation);
+            }
+            finally
+            {
+                ExecuteHooks<PostHookAttribute>(type, commandInvocation);
+            }
+        }
+
+        private void ExecuteHooks<T>(Type type, CommandInvocation commandInvocation) where T : Attribute
+        {
+            var methodInfos = type.GetMethods().Where(m => CustomAttributeProviderExtensions.HasAttribute<T>(m)).ToArray();
+            if (methodInfos.Length > 1)
+            {
+                throw new Exception($"{type.Name} can only have 1 {nameof(T)} but has {methodInfos.Length}");
+            }
+
+            var hook = methodInfos.SingleOrDefault();
+            if (hook == null)
+            {
+                return;
+            }
+
+            var parameterInfos = hook.GetParameters();
+            if (parameterInfos.Any(p => !typeof(IArgumentModel).IsAssignableFrom(p.ParameterType)))
+            {
+                throw new Exception($"{type.Name} {nameof(T)} only supports paramters of type IArgumentModel");
+            }
+            var argumentModels = parameterInfos
+                .Select(p => commandInvocation.ParamsForCommandMethod.FirstOrDefault(m => p.ParameterType.IsInstanceOfType(m)))
+                .ToArray();
+
+            hook.Invoke(commandInvocation.Instance, argumentModels);
+        }
+    }
+}

--- a/CommandDotNet/CommandInvoker/PrePostHookCommandInvoker.cs
+++ b/CommandDotNet/CommandInvoker/PrePostHookCommandInvoker.cs
@@ -5,13 +5,13 @@ using CommandDotNet.Extensions;
 namespace CommandDotNet.CommandInvoker
 {
 
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class PreHookAttribute : Attribute
     {
         
     }
     
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method)]
     public class PostHookAttribute : Attribute
     {
         

--- a/CommandDotNet/Models/AppSettings.cs
+++ b/CommandDotNet/Models/AppSettings.cs
@@ -6,6 +6,8 @@ namespace CommandDotNet.Models
 {
     public class AppSettings
     {
+        private bool _enableCommandHooks;
+        
         public AppSettings()
         {
             if(BooleanMode == BooleanMode.Unknown)
@@ -23,7 +25,24 @@ namespace CommandDotNet.Models
         public Case Case { get; set; } = Case.DontChange;
 
         public bool EnableVersionOption { get; set; } = true;
-        
+
+        public bool EnableCommandHooks
+        {
+            get => _enableCommandHooks;
+            set
+            {
+                _enableCommandHooks = value;
+                if (value)
+                {
+                    CommandInvoker = new PrePostHookCommandInvoker(new DefaultCommandInvoker());
+                }
+                else
+                {
+                    CommandInvoker = new DefaultCommandInvoker();
+                }
+            }
+        }
+
         public bool PrompForArgumentsIfNotProvided { get; set; }
 
         public HelpTextStyle HelpTextStyle { get; set; } = HelpTextStyle.Detailed;


### PR DESCRIPTION
@bilal-fazlani here's a spike of implementing pre & post-hooks functionality for design review.  I think this would solve #55 for the most part.  All hook params have to be IArgumentModel.  I'm not familiar enough with the internal mapping code to support more than that.