### PR TITLE
fixes parsing errors for non us/invariant console runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ output
 .vscode
 CommandDotNet.sln.DotSettings.user
 .vs/
+*.ncrunchsolution.user

--- a/CommandDotNet/Parsing/SingleValueParser.cs
+++ b/CommandDotNet/Parsing/SingleValueParser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using CommandDotNet.Exceptions;
 using CommandDotNet.Models;
 
@@ -44,7 +45,7 @@ namespace CommandDotNet.Parsing
 
                 if (_underyingType == typeof(double))
                 {
-                    return double.Parse(value);
+                    return double.Parse(value, CultureInfo.InvariantCulture);
                 }
 
                 if (_underyingType == typeof(long))


### PR DESCRIPTION
this would fix #60 and should work for all clients. while being able to specify the locale would be the best path, fixing it like this for now, would make sure that it at least isn't causing errors for some users.