### PR TITLE
Brackets parsing error fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# Informationen zu EDITORCONFIG-Dateien finden Sie unter https://aka.ms/editorconfigdocs
+
+# All files
+[*]
+indent_style = space
+indent_size = 4
+
+# Xml files
+[*.xml]
+indent_size = 2

--- a/CommandDotNet.Tests/NestedCommandsTest.cs
+++ b/CommandDotNet.Tests/NestedCommandsTest.cs
@@ -22,7 +22,7 @@ namespace CommandDotNet.Tests
         [InlineData(2, new[]{"stash"})]
         
         // typical scenario
-        [InlineData(5, new[]{"commit", "-m", "added new feature"})]
+        [InlineData(5, new[]{"commit", "-m", "\"added new feature\""})]
         
         // external module
         [InlineData(6, new[]{"submodule","add"})]

--- a/CommandDotNet.Tests/Parsing/ArgumentParserTests.cs
+++ b/CommandDotNet.Tests/Parsing/ArgumentParserTests.cs
@@ -14,6 +14,7 @@ namespace CommandDotNet.Tests.Parsing
         [Theory]
         [InlineData("dotnet example.dll --key=value", new string[] { "dotnet", "example.dll", "--key=value" })]
         [InlineData("test config \"sometext (and more)\"", new string[] { "test", "config", "sometext (and more)" })]
+        [InlineData("test config -ab", new string[] { "test", "config", "-a", "-b" })]
         public void TestInputValues(string input, string[] expectedResult)
         {
             var chunks = input.Split(" ");

--- a/CommandDotNet.Tests/Parsing/ArgumentParserTests.cs
+++ b/CommandDotNet.Tests/Parsing/ArgumentParserTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.Parsing
+{
+    public class ArgumentParserTests : TestBase
+    {
+        /// <inheritdoc />
+        public ArgumentParserTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Theory]
+        [InlineData("dotnet example.dll --key=value", new string[] { "dotnet", "example.dll", "--key=value" })]
+        [InlineData("test config \"sometext (and more)\"", new string[] { "test", "config", "sometext (and more)" })]
+        public void TestInputValues(string input, string[] expectedResult)
+        {
+            var chunks = input.Split(" ");
+            var parsed = ArgumentParser.SplitFlags(chunks);
+            parsed.Should().BeEquivalentTo(expectedResult);
+        }
+    }
+}

--- a/CommandDotNet.Tests/Parsing/StringValueParserTests.cs
+++ b/CommandDotNet.Tests/Parsing/StringValueParserTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CommandDotNet.Attributes;
+using CommandDotNet.Models;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.Parsing
+{
+    public class StringValueParserTests : TestBase
+    {
+        [Theory]
+        [InlineData("test config sometext", 0)]
+        [InlineData("test config \"sometext (and more)\"", 0)]
+        public void TestValues(string input, int expectedCode)
+        {
+            var app = new AppRunner<StringValueApplication>(new AppSettings(){Case = Case.LowerCase});
+            var result = app.Run(input.Split(' '));
+            result.Should().Be(expectedCode);
+        }
+
+        private class StringValueApplication
+        {
+            public int Test(
+                [Argument(Name = "action")]
+                string actionType,
+                string text)
+            {
+                return 0;
+            }
+        }
+
+        /// <inheritdoc />
+        public StringValueParserTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+    }
+}

--- a/CommandDotNet.Tests/TestCases/MyTestApp.TestMethodParams.Input.json
+++ b/CommandDotNet.Tests/TestCases/MyTestApp.TestMethodParams.Input.json
@@ -4,7 +4,7 @@
             "testCaseName": "can recognise string, int, string array, double & few null entries",
             "params" : [
                 "TestMethodParams",
-                "--name", "bilal fazlani",
+                "--name", "\"bilal fazlani\"",
                 "--id", "4",
                 "--tag", "human",
                 "-t", "male",

--- a/CommandDotNet/Parsing/SingleValueParser.cs
+++ b/CommandDotNet/Parsing/SingleValueParser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using CommandDotNet.Exceptions;
 using CommandDotNet.Models;
 
@@ -44,7 +45,7 @@ namespace CommandDotNet.Parsing
 
                 if (_underyingType == typeof(double))
                 {
-                    return double.Parse(value);
+                    return double.Parse(value, CultureInfo.InvariantCulture);
                 }
 
                 if (_underyingType == typeof(long))


### PR DESCRIPTION
Enables proper usage of arguments which are supposed to be multiple text tokens, seperated by spaces.