### PR TITLE
Help text tests

### DIFF
--- a/CommandDotNet.Tests/HelpTests/UsageTests.cs
+++ b/CommandDotNet.Tests/HelpTests/UsageTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommandDotNet.Attributes;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.HelpTests
+{
+    public class UsageTests : TestBase
+    {
+        private List<string> _output = new List<string>();
+        
+        public UsageTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+            base.CaptureOutputLine(CaptureOutput);
+        }
+
+        private void CaptureOutput(object sender, string e)
+        {
+            _output.Add(e);
+        }
+
+        [Fact]
+        public void UsageShouldPrintSubcommandsInCorrectOrder()
+        {
+            new AppRunner<HelpApp>().Run("SubHelpCommand", "Print", "--help");
+            var helpText = _output.First().Split(new[] {"\r\n", "\r", "\n"}, StringSplitOptions.RemoveEmptyEntries);
+            var usage = helpText.Single(o => o.StartsWith("Usage")).Substring("Usage: ".Length);
+            usage.Should().Be("dotnet testhost.dll SubHelpCommand Print [arguments] [options]");
+        }
+        
+        public class HelpApp
+        {
+            [SubCommand]
+            public SubHelpCommand SubCommand { get; set; }
+            
+            public class SubHelpCommand
+            {
+                public void Print(string helpText)
+                {
+                    
+                } 
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/TestBase.cs
+++ b/CommandDotNet.Tests/TestBase.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using CommandDotNet.Models;
 using Xunit.Abstractions;
 
@@ -9,12 +11,14 @@ namespace CommandDotNet.Tests
         protected readonly ITestOutputHelper TestOutputHelper;
         protected readonly TestConsoleWriter TestConsoleWriter;
 
+        private List<EventHandler<string>> _outputHandlers = new List<EventHandler<string>>();
+
         public TestBase(ITestOutputHelper testOutputHelper)
         {
             TestOutputHelper = testOutputHelper;
             TestConsoleWriter = new TestConsoleWriter();
-            
-            TestConsoleWriter.WriteLineEvent += OnWriteLine;
+
+            CaptureOutputLine(OnWriteLine);
             
             Console.SetOut(TestConsoleWriter);
             Console.SetError(TestConsoleWriter);
@@ -32,9 +36,18 @@ namespace CommandDotNet.Tests
             }
         }
 
+        protected void CaptureOutputLine(EventHandler<string> handler)
+        {
+            TestConsoleWriter.WriteLineEvent += handler;
+            _outputHandlers.Append(handler);
+        }
+
         public void Dispose()
         {
-            TestConsoleWriter.WriteLineEvent -= OnWriteLine;
+            foreach (var handler in _outputHandlers)
+            {
+                TestConsoleWriter.WriteLineEvent -= handler;
+            }
             TestConsoleWriter.Dispose();
         }
     }

--- a/CommandDotNet/MicrosoftCommandLineUtils/CommandLineApplication.cs
+++ b/CommandDotNet/MicrosoftCommandLineUtils/CommandLineApplication.cs
@@ -53,7 +53,7 @@ namespace CommandDotNet.MicrosoftCommandLineUtils
 
         public string GetFullCommandName()
         {
-            return string.Join(" ", GetSelfAndParentCommands().Select(c => c.Name));
+            return string.Join(" ", GetSelfAndParentCommands().Reverse().Select(c => c.Name));
         } 
 
         public IEnumerable<CommandOption> GetOptions()


### PR DESCRIPTION
@bilal-fazlani, this has the test for #74.  I don't like capturing the help text this way.  It will have race conditions with other tests when run in parellel.    Since help is output to the console, I don't know of a good way to isolate the output for the running test.  Do you have any suggestions?