### PR TITLE
create bdd tests for ArgumentSeparator

### DIFF
--- a/CommandDotNet.Tests/BddTests/Apps/ArgSamplesApp.cs
+++ b/CommandDotNet.Tests/BddTests/Apps/ArgSamplesApp.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using CommandDotNet.Attributes;
+using CommandDotNet.Tests.Utils;
+
+namespace CommandDotNet.Tests.BddTests.Apps
+{
+    public class ArgSamplesApp
+    {
+        [InjectProperty]
+        public TestOutputs TestOutputs { get; set; }
+
+        public void List(
+            [Argument]
+            List<string> extras)
+        {
+            this.TestOutputs.Capture(new ListResults{Extras = extras});
+        }
+
+        public void ListPlusOne(
+            [Argument]
+            string one,
+            [Argument]
+            List<string> extras)
+        {
+            this.TestOutputs.Capture(new ListResults
+            {
+                One = one,
+                Extras = extras
+            });
+        }
+
+        public class ListResults
+        {
+            public string One { get; set; }
+            public List<string> Extras { get; set; }
+        }
+    }
+}

--- a/CommandDotNet.Tests/BddTests/ScenarioTests.cs
+++ b/CommandDotNet.Tests/BddTests/ScenarioTests.cs
@@ -23,6 +23,7 @@ namespace CommandDotNet.Tests.BddTests
         [ClassData(typeof(BasicHelpAndVersionDetailedHelpScenarios))]
         [ClassData(typeof(SingleCommandAppDetailedHelpScenarios))]
         [ClassData(typeof(DefaultCommandDetailedHelpScenarios))]
+        [ClassData(typeof(ArgumentSeparatorHelpScenarios))]
         public void Help(IScenario scenario)
         {
             try
@@ -46,6 +47,7 @@ namespace CommandDotNet.Tests.BddTests
         [Theory]
         [ClassData(typeof(BasicParseScenarios))]
         [ClassData(typeof(DefaultCommandParseScenarios))]
+        [ClassData(typeof(ArgumentSeparatorParseScenarios))]
         public void Parse(IScenario scenario)
         {
             try

--- a/CommandDotNet.Tests/BddTests/TestScenarios/ArgumentSeparatorHelpScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/ArgumentSeparatorHelpScenarios.cs
@@ -1,0 +1,24 @@
+using CommandDotNet.Models;
+using CommandDotNet.Tests.BddTests.Apps;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class ArgumentSeparatorHelpScenarios : ScenariosBaseTheory
+    {
+        private readonly AppSettings _argSeparatorEnabled = new AppSettings { AllowArgumentSeparator = true };
+
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                new Given<SingleCommandApp>("help example includes argument separator")
+                {
+                    And = {AppSettings = _argSeparatorEnabled},
+                    WhenArgs = "Add -h",
+                    Then =
+                    {
+                        HelpContainsTexts = {@"Usage: dotnet testhost.dll Add [arguments] [options] [[--] <arg>...]"}
+                    }
+                }
+            };
+    }
+}

--- a/CommandDotNet.Tests/BddTests/TestScenarios/ArgumentSeparatorParseScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/ArgumentSeparatorParseScenarios.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using CommandDotNet.Models;
+using CommandDotNet.Tests.BddTests.Apps;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class ArgumentSeparatorParseScenarios: ScenariosBaseTheory
+    {
+        private readonly AppSettings _argSeparatorEnabled = new AppSettings {AllowArgumentSeparator = true};
+        private readonly AppSettings _argSeparatorDisabled = new AppSettings {AllowArgumentSeparator = false};
+
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                // TODO: these scenarios need better names after this is working
+                new Given<ArgSamplesApp>("list _argSeparatorDisabled 1")
+                {
+                    And = {AppSettings = _argSeparatorDisabled},
+                    WhenArgs = "list -- a1 b2 c3",
+                    Then = {HelpContainsTexts = {"Unrecognized option '--'"}}
+                },
+                new Given<ArgSamplesApp>("list _argSeparatorEnabled 1")
+                {
+                    And = {AppSettings = _argSeparatorEnabled},
+                    WhenArgs = "list -- a1 b2 c3",
+                    Then = { Outputs =
+                    {
+                        new ArgSamplesApp.ListResults{Extras = new List<string>{"a1", "b2", "c3"}}
+                    }}
+                },
+                new Given<ArgSamplesApp>("ListPlusOne _argSeparatorDisabled 1")
+                {
+                    And = {AppSettings = _argSeparatorDisabled},
+                    WhenArgs = "ListPlusOne one -- a1 b2 c3",
+                    Then = {HelpContainsTexts = {"Unrecognized option '--'"}}
+                },
+                new Given<ArgSamplesApp>("ListPlusOne _argSeparatorEnabled 1")
+                {
+                    And = {AppSettings = _argSeparatorEnabled},
+                    WhenArgs = "ListPlusOne one -- a1 b2 c3",
+                    Then = { Outputs =
+                    {
+                        new ArgSamplesApp.ListResults
+                        {
+                            One = "one",
+                            Extras = new List<string>{"a1", "b2", "c3"}
+                        }
+                    }}
+                }
+            };
+    }
+}


### PR DESCRIPTION
these are failling.  looks like ThrowOnUnexpectedArgument also has to be true.

@bilal-fazlani I wrote these tests for the argument separator.  It looks like all args after `--` are placed in a RemainingArgs list and never passed to the command method.  I didn't see any documentation on the feature.  How should it work?