### PR TITLE
Add subcommand help tests, fix help usage

### DIFF
--- a/CommandDotNet.Example/Program.cs
+++ b/CommandDotNet.Example/Program.cs
@@ -1,4 +1,5 @@
-﻿using CommandDotNet.Attributes;
+﻿using System;
+using CommandDotNet.Attributes;
 using CommandDotNet.Example.Issues;
 using CommandDotNet.Models;
 
@@ -36,5 +37,10 @@ namespace CommandDotNet.Example
 
         [SubCommand]
         public IssueApps IssueApps { get; set; }
+
+        public void Add(int x, int y)
+        {
+            Console.Out.WriteLine(x+y);
+        }
     }
 }

--- a/CommandDotNet.Tests/AppRunnerResult.cs
+++ b/CommandDotNet.Tests/AppRunnerResult.cs
@@ -28,5 +28,12 @@ namespace CommandDotNet.Tests
             expected = expected.NormalizeLineEndings();
             actual.Should().Be(expected);
         }
+
+        public bool HelpContains(string expected)
+        {
+            var actual = ConsoleOut.NormalizeLineEndings();
+            expected = expected.NormalizeLineEndings();
+            return actual.Contains(expected);
+        }
     }
 }

--- a/CommandDotNet.Tests/BddTests/Apps/SingleCommandApp.cs
+++ b/CommandDotNet.Tests/BddTests/Apps/SingleCommandApp.cs
@@ -3,6 +3,7 @@ using CommandDotNet.Tests.Utils;
 
 namespace CommandDotNet.Tests.BddTests.Apps
 {
+    [ApplicationMetadata(Name = "Math")]
     public class SingleCommandApp
     {
         [InjectProperty]

--- a/CommandDotNet.Tests/BddTests/Apps/SubCommandApp.cs
+++ b/CommandDotNet.Tests/BddTests/Apps/SubCommandApp.cs
@@ -1,0 +1,10 @@
+using CommandDotNet.Attributes;
+
+namespace CommandDotNet.Tests.BddTests.Apps
+{
+    public class SubCommandApp
+    {
+        [SubCommand]
+        public SingleCommandApp Math { get; set; }
+    }
+}

--- a/CommandDotNet.Tests/BddTests/ScenarioTests.cs
+++ b/CommandDotNet.Tests/BddTests/ScenarioTests.cs
@@ -99,7 +99,7 @@ namespace CommandDotNet.Tests.BddTests
         {
             var expectedExitCode = scenario.Then.ExitCode.GetValueOrDefault();
             var missingHelpTexts = scenario.Then.HelpContainsTexts
-                .Where(t => !result.ConsoleOut.Contains(t))
+                .Where(t => !result.HelpContains(t))
                 .ToList();
 
             if (expectedExitCode != result.ExitCode || missingHelpTexts.Count > 0)

--- a/CommandDotNet.Tests/BddTests/TestScenarios/SubCommandScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/SubCommandScenarios.cs
@@ -1,0 +1,81 @@
+using CommandDotNet.Tests.BddTests.Apps;
+using CommandDotNet.Tests.BddTests.Framework;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class SubCommandScenarios : ScenariosBaseTheory
+    {
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                new Given<SubCommandApp>("help lists sub-commands")
+                {
+                    WhenArgs = null,
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll [options] [command]
+
+Options:
+
+  -v | --version
+  Show version information
+
+  -h | --help
+  Show help information
+
+
+Commands:
+
+  Math
+
+Use ""dotnet testhost.dll [command] --help"" for more information about a command."
+                    }
+                },
+                new Given<SubCommandApp>("help for sub-command shows sub-command options and sub-commands")
+                {
+                    WhenArgs = "Math",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll Math [options] [command]
+
+Options:
+
+  -h | --help
+  Show help information
+
+
+Commands:
+
+  Add
+
+Use ""dotnet testhost.dll Math [command] --help"" for more information about a command."
+                    }
+                },
+                new Given<SubCommandApp>("help for nested sub-command shows nested sub-command arguments and options")
+                {
+                    WhenArgs = "Math Add -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll Math Add [arguments] [options]
+
+Arguments:
+
+  x    <NUMBER>
+  the first operand
+
+  y    <NUMBER>
+  the second operand
+
+
+Options:
+
+  -h | --help
+  Show help information
+
+  -o | --operator    <TEXT>    [+]
+  the operation to apply"
+                    }
+                }
+            };
+    }
+}

--- a/CommandDotNet/AppCreator.cs
+++ b/CommandDotNet/AppCreator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -37,24 +38,32 @@ namespace CommandDotNet
             if (isRootApp)
             {
                 app = new CommandLineApplication(_appSettings);
+
+                // _hostAssembly can be null when loaded from tests. see Issue #65
+                if (_hostAssembly != null)
+                {
+                    app.Name = Path.GetFileName(_hostAssembly.Location);
+                    app.FullName = Path.GetFileName(_hostAssembly.Location).EndsWith(".exe") 
+                        ? Path.GetFileName(_hostAssembly.Location) 
+                        : $"dotnet {Path.GetFileName(_hostAssembly.Location)}";
+                }
+
+                /*
                 string rootCommandName = consoleApplicationAttribute?.Name;
                 if (rootCommandName != null)
                 {
-                    app.Name = rootCommandName;
-                    app.FullName = rootCommandName;
+                    app.Name = app.Name == null
+                        ? rootCommandName
+                        : app.Name = $"{app.Name} {rootCommandName}";
                 }
-                else if(_hostAssembly != null)
+                */
+
+                if(app.Name == null)
                 {
-                    string assemblyName = $"{_hostAssembly.GetName().Name}.dll";
-                    app.Name = $"dotnet {assemblyName}";
-                    app.FullName = assemblyName;
+                    // this is only expected to happen in tests
+                    app.FullName = app.Name = "...";
                 }
-                else
-                {
-                    app.Name = "...";
-                    app.FullName = "...";
-                }
-                
+
                 AddVersion(app);
             }
             else

--- a/CommandDotNet/MicrosoftCommandLineUtils/CommandLineApplication.cs
+++ b/CommandDotNet/MicrosoftCommandLineUtils/CommandLineApplication.cs
@@ -47,7 +47,7 @@ namespace CommandDotNet.MicrosoftCommandLineUtils
 
         public string GetFullCommandName()
         {
-            return string.Join(" ", GetSelfAndParentCommands().Reverse().Select(c => c.Name));
+            return string.Join(" ", GetSelfAndParentCommands().Reverse().Select(c => c.FullName ?? c.Name));
         } 
 
         public IEnumerable<CommandOption> GetOptions()
@@ -343,7 +343,7 @@ namespace CommandDotNet.MicrosoftCommandLineUtils
 
         public void ShowVersion()
         {
-            _appSettings.Out.WriteLine(FullName);
+            _appSettings.Out.WriteLine(Name);
             _appSettings.Out.WriteLine(LongVersionGetter());
         }
 


### PR DESCRIPTION
Fixed:
- help usage: command name was invalid when root command
  had ApplicationMetadata.Name assignment
- help usage: "dotnet " prefix only included when the file isn't
  an executable
- version help: include "dotnet " which is only relevant for
  executing the app when not an .exe

Enhanced:
- HelpContainsText can include multiple lines.  line endings
  are normalized to extra white spaces excluding, matching
  behavior of the `Help =` check