### PR TITLE
3 Add bdd tests for global options: help & exec

### DIFF
--- a/CommandDotNet.Tests/BddTests/Framework/ScenarioThen.cs
+++ b/CommandDotNet.Tests/BddTests/Framework/ScenarioThen.cs
@@ -7,6 +7,7 @@ namespace CommandDotNet.Tests.BddTests.Framework
     {
         public int? ExitCode { get; set; }
         public string Help { get; set; }
+        public bool OutputsStrict { get; set; }
         public List<object> Outputs { get; } = new List<object>();
         public List<string> HelpContainsTexts { get; } = new List<string>();
     }

--- a/CommandDotNet.Tests/BddTests/ScenarioTests.cs
+++ b/CommandDotNet.Tests/BddTests/ScenarioTests.cs
@@ -135,6 +135,18 @@ namespace CommandDotNet.Tests.BddTests
                     .NotBeNull(because: $"{expectedOutput.GetType().Name} should have been output in test run");
                 actualOutput.Should().BeEquivalentTo(expectedOutput);
             }
+
+            var actualOutputs = results.TestOutputs.Outputs;
+            if (scenario.Then.OutputsStrict && actualOutputs.Count > scenario.Then.Outputs.Count)
+            {
+                var expectedOutputTypes = scenario.Then.Outputs.Select(o => o.GetType()).ToHashSet();
+                var unexpectedTypes = string.Join(",", actualOutputs.Keys
+                    .Where(t => !expectedOutputTypes.Contains(t))
+                    .Select(t => t.Name)
+                    .OrderBy(n => n));
+
+                throw new AssertionFailedException($"Unexpected output: {unexpectedTypes}");
+            }
         }
     }
 }

--- a/CommandDotNet.Tests/BddTests/TestScenarios/FlagScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/FlagScenarios.cs
@@ -1,0 +1,47 @@
+using CommandDotNet.Attributes;
+using CommandDotNet.Tests.BddTests.Framework;
+using CommandDotNet.Tests.Utils;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class FlagScenarios : ScenariosBaseTheory
+    {
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                new Given<FlagApp>($"help is boolean")
+                {
+                    WhenArgs = "Do -h",
+                    Then = {Help = @"Usage: dotnet testhost.dll Do [options]
+
+Options:
+
+  -h | --help
+  Show help information
+
+  --flag" }
+                },
+                new Given<FlagApp>($"when specified, flag is true")
+                {
+                    WhenArgs = "Do --flag",
+                    Then = {Outputs = {true}}
+                },
+                new Given<FlagApp>($"when not specified, flag is false")
+                {
+                    WhenArgs = "Do",
+                    Then = {Outputs = {false}}
+                },
+            };
+
+        private class FlagApp
+        {
+            [InjectProperty]
+            public TestOutputs TestOutputs { get; set; }
+
+            public void Do([Option] bool flag)
+            {
+                TestOutputs.Capture(flag);
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/BddTests/TestScenarios/GlobalOptionsInheritedScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/GlobalOptionsInheritedScenarios.cs
@@ -1,0 +1,159 @@
+using CommandDotNet.Attributes;
+using CommandDotNet.Tests.BddTests.Framework;
+using CommandDotNet.Tests.Utils;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class GlobalOptionsInheritedScenarios : ScenariosBaseTheory
+    {
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                new Given<Root>("help includes global options")
+                {
+                    WhenArgs = "-h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll [options] [command]
+
+Options:
+
+  -v | --version
+  Show version information
+
+  -h | --help
+  Show help information
+
+  --rootOpt         <TEXT>
+
+
+Commands:
+
+  Leaf
+
+Use ""dotnet testhost.dll [command] --help"" for more information about a command."
+                    }
+                },
+                new Given<Root>("help for sub-command includes local and inherited root global options")
+                {
+                    WhenArgs = "Leaf -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll Leaf [options] [command]
+
+Options:
+
+  -h | --help
+  Show help information
+
+  --LeafOpt      <TEXT>
+
+  --rootOpt      <TEXT>
+
+
+Commands:
+
+  Do
+
+Use ""dotnet testhost.dll Leaf [command] --help"" for more information about a command."
+                    }
+                },
+                new Given<Root>("executing sub-command will parse and execute local global options")
+                {
+                    WhenArgs = "--rootOpt root Leaf --LeafOpt leaf Do --DoOpt a b",
+                    Then =
+                    {
+                        OutputsStrict = true,
+                        Outputs =
+                        {
+                            //new RootGlobalResult{RootOpt = "root"},
+                            new LeafGlobalResult{LeafOpt = "leaf"},
+                            new LeafDoResult{DoOpt = "a", DoArg = "b"}
+                        }
+                    }
+                },
+                new Given<Root>("global option can be specified after local command")
+                {
+                    WhenArgs = "Leaf Do --LeafOpt leaf --rootOpt root --DoOpt a b",
+                    Then =
+                    {
+                        OutputsStrict = true,
+                        Outputs =
+                        {
+                            //new RootGlobalResult{RootOpt = "root"},
+                            new LeafGlobalResult{LeafOpt = "leaf"},
+                            new LeafDoResult{DoOpt = "a", DoArg = "b"}
+                        }
+                    }
+                }
+            };
+
+        public class Root
+        {
+            private readonly string _rootOpt;
+
+            private TestOutputs _testOutputs;
+
+            [InjectProperty]
+            public TestOutputs TestOutputs
+            {
+                get => _testOutputs;
+                set
+                {
+                    _testOutputs = value;
+                    _testOutputs.Capture(new RootGlobalResult{RootOpt = _rootOpt});
+                }
+            }
+
+            public Root([Option(Inherited = true)] string rootOpt)
+            {
+                _rootOpt = rootOpt;
+            }
+
+            [SubCommand]
+            public Leaf Leaf { get; set; }
+        }
+
+        public class Leaf
+        {
+            private readonly LeafGlobalResult _leafGlobalResult;
+
+            [InjectProperty]
+            public TestOutputs TestOutputs { get; set; }
+
+            public Leaf(LeafGlobalResult leafGlobalResult)
+            {
+                // TestOutputs property isn't injected yet
+                _leafGlobalResult = leafGlobalResult;
+            }
+
+            public void Do(LeafDoResult leafDoResult)
+            {
+                TestOutputs.Capture(_leafGlobalResult);
+                TestOutputs.Capture(leafDoResult);
+            }
+        }
+
+        public class RootGlobalResult 
+        {
+            [Option]
+            public string RootOpt { get; set; }
+        }
+
+        public class LeafGlobalResult : IArgumentModel
+        {
+            [Option(Inherited = true)]
+            public string LeafOpt { get; set; }
+        }
+
+        public class LeafDoResult : IArgumentModel
+        {
+            [Option]
+            public string DoOpt { get; set; }
+            [Argument]
+            public string DoArg { get; set; }
+
+            internal string InheritedRootOpt { get; set; }
+        }
+    }
+}

--- a/CommandDotNet.Tests/BddTests/TestScenarios/GlobalOptionsScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/GlobalOptionsScenarios.cs
@@ -1,0 +1,137 @@
+using CommandDotNet.Attributes;
+using CommandDotNet.Tests.BddTests.Framework;
+using CommandDotNet.Tests.Utils;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class GlobalOptionsScenarios : ScenariosBaseTheory
+    {
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                new Given<Root>("help includes global options")
+                {
+                    WhenArgs = "-h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll [options] [command]
+
+Options:
+
+  -v | --version
+  Show version information
+
+  -h | --help
+  Show help information
+
+  --rootOpt         <TEXT>
+
+
+Commands:
+
+  Leaf
+
+Use ""dotnet testhost.dll [command] --help"" for more information about a command."
+                    }
+                },
+                new Given<Root>("help for sub-command includes only local global options")
+                {
+                    WhenArgs = "Leaf -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll Leaf [options] [command]
+
+Options:
+
+  -h | --help
+  Show help information
+
+  --LeafOpt      <TEXT>
+
+
+Commands:
+
+  Do
+
+Use ""dotnet testhost.dll Leaf [command] --help"" for more information about a command."
+                    }
+                },
+                new Given<Root>("executing sub-command will parse and execute local global options")
+                {
+                    WhenArgs = "Leaf --LeafOpt leaf Do --DoOpt a b",
+                    Then =
+                    {
+                        OutputsStrict = true,
+                        Outputs =
+                        {
+                            new LeafGlobalResult{LeafOpt = "leaf"},
+                            new LeafDoResult{DoOpt = "a", DoArg = "b"}
+                        }
+                    }
+                },
+                new Given<Root>("global option must be specified before local command")
+                {
+                    WhenArgs = "Leaf Do --LeafOpt leaf --DoOpt a b",
+                    Then =
+                    {
+                        ExitCode = 1,
+                        HelpContainsTexts = { "Unrecognized option '--LeafOpt'" }
+                    }
+                }
+            };
+
+        public class Root
+        {
+            [InjectProperty]
+            public TestOutputs TestOutputs { get; set; }
+
+            public Root([Option] string rootOpt)
+            {
+                TestOutputs.Capture(new RootGlobalResult{RootOpt = rootOpt});
+            }
+
+            [SubCommand]
+            public Leaf Leaf { get; set; }
+        }
+
+        public class Leaf
+        {
+            private readonly LeafGlobalResult _leafGlobalResult;
+
+            [InjectProperty]
+            public TestOutputs TestOutputs { get; set; }
+
+            public Leaf(LeafGlobalResult leafGlobalResult)
+            {
+                // TestOutputs property isn't injected yet
+                _leafGlobalResult = leafGlobalResult;
+            }
+
+            public void Do(LeafDoResult leafDoResult)
+            {
+                TestOutputs.Capture(_leafGlobalResult);
+                TestOutputs.Capture(leafDoResult);
+            }
+        }
+
+        public class RootGlobalResult 
+        {
+            [Option]
+            public string RootOpt { get; set; }
+        }
+
+        public class LeafGlobalResult : IArgumentModel
+        {
+            [Option]
+            public string LeafOpt { get; set; }
+        }
+
+        public class LeafDoResult : IArgumentModel
+        {
+            [Option]
+            public string DoOpt { get; set; }
+            [Argument]
+            public string DoArg { get; set; }
+        }
+    }
+}

--- a/CommandDotNet.Tests/BddTests/TestScenarios/OptionalParamsScenarios.cs
+++ b/CommandDotNet.Tests/BddTests/TestScenarios/OptionalParamsScenarios.cs
@@ -1,0 +1,244 @@
+using System;
+using CommandDotNet.Attributes;
+using CommandDotNet.Tests.BddTests.Framework;
+using CommandDotNet.Tests.Utils;
+
+namespace CommandDotNet.Tests.BddTests.TestScenarios
+{
+    public class OptionalParamsScenarios : ScenariosBaseTheory
+    {
+        public override Scenarios Scenarios =>
+            new Scenarios
+            {
+                new Given<OptionalParamsApp>("help displays args defined with nulled string")
+                {
+                    WhenArgs = "NullString -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll NullString [arguments] [options]
+
+Arguments:
+
+  stringArg    <TEXT>
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("help displays args defined with defaulted string")
+                {
+                    WhenArgs = "DefaultString -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll DefaultString [arguments] [options]
+
+Arguments:
+
+  stringArg    <TEXT>    [some-default]
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("executes with value passed to nulled string")
+                {
+                    WhenArgs = "NullString some-value",
+                    Then = {Outputs = {new RunResults {StringArg = "some-value"}}}
+                },
+                new Given<OptionalParamsApp>("executes with no value passed to nulled string")
+                {
+                    WhenArgs = "NullString",
+                    Then = {Outputs = {new RunResults{StringArg = null}}}
+                },
+                new Given<OptionalParamsApp>("executes with value passed to defaulted string")
+                {
+                    WhenArgs = "DefaultString some-value",
+                    Then = {Outputs = {new RunResults {StringArg = "some-value"}}}
+                },
+                new Given<OptionalParamsApp>("executes with no value passed to defaulted string")
+                {
+                    WhenArgs = "DefaultString",
+                    Then = {Outputs = {new RunResults{StringArg = "some-default"}}}
+                },
+                new Given<OptionalParamsApp>("help displays args defined with nulled object")
+                {
+                    WhenArgs = "NullObject -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll NullObject [arguments] [options]
+
+Arguments:
+
+  uriArg    <URI>
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("help displays args defined with nulled object")
+                {
+                    WhenArgs = "NullObject -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll NullObject [arguments] [options]
+
+Arguments:
+
+  uriArg    <URI>
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("executes with value passed to nulled object")
+                {
+                    WhenArgs = "NullObject http://google.com",
+                    Then = {Outputs = {new RunResults {UriArg = new Uri("http://google.com")}}}
+                },
+                new Given<OptionalParamsApp>("executes with no value passed to nulled object")
+                {
+                    WhenArgs = "NullObject",
+                    Then = {Outputs = {new RunResults{UriArg = null}}}
+                },
+                new Given<OptionalParamsApp>("help displays args defined with defaulted int")
+                {
+                    WhenArgs = "DefaultInt -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll DefaultInt [arguments] [options]
+
+Arguments:
+
+  intArg    <NUMBER>    [1]
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("executes with value passed to defaulted int")
+                {
+                    WhenArgs = "DefaultInt 5",
+                    Then = {Outputs = {new RunResults {IntArg = 5}}}
+                },
+                new Given<OptionalParamsApp>("executes with no value passed to defaulted int")
+                {
+                    WhenArgs = "DefaultInt",
+                    Then = {Outputs = {new RunResults {IntArg = 1}}}
+                },
+                new Given<OptionalParamsApp>("help displays args defined with nulled int?")
+                {
+                    WhenArgs = "NullNullableInt -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll NullNullableInt [arguments] [options]
+
+Arguments:
+
+  intArg    <NUMBER>
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("help displays args defined with defaulted int?")
+                {
+                    WhenArgs = "DefaultNullableInt -h",
+                    Then =
+                    {
+                        Help = @"Usage: dotnet testhost.dll DefaultNullableInt [arguments] [options]
+
+Arguments:
+
+  intArg    <NUMBER>    [1]
+
+
+Options:
+
+  -h | --help
+  Show help information"
+                    }
+                },
+                new Given<OptionalParamsApp>("executes with value passed to nulled int?")
+                {
+                    WhenArgs = "NullNullableInt 5",
+                    Then = {Outputs = {new RunResults {IntArg = 5}}}
+                },
+                new Given<OptionalParamsApp>("executes with no value passed to nulled int?")
+                {
+                    WhenArgs = "NullNullableInt",
+                    Then = {Outputs = {new RunResults {IntArg = null}}}
+                },
+                new Given<OptionalParamsApp>("executes with value passed to defaulted int?")
+                {
+                    WhenArgs = "DefaultNullableInt 5",
+                    Then = {Outputs = {new RunResults {IntArg = 5}}}
+                },
+                new Given<OptionalParamsApp>("executes with no value passed to defaulted int?")
+                {
+                    WhenArgs = "DefaultNullableInt",
+                    Then = {Outputs = {new RunResults {IntArg = 1}}}
+                },
+            };
+
+        private class OptionalParamsApp
+        {
+            [InjectProperty]
+            public TestOutputs TestOutputs { get; set; }
+
+            public void NullString(string stringArg = null)
+            {
+                TestOutputs.Capture(new RunResults{StringArg = stringArg});
+            }
+
+            public void DefaultString(string stringArg = "some-default")
+            {
+                TestOutputs.Capture(new RunResults { StringArg = stringArg });
+            }
+
+            public void NullObject(Uri uriArg = null)
+            {
+                TestOutputs.Capture(new RunResults { UriArg = uriArg });
+            }
+
+            public void NullNullableInt(int? intArg = null)
+            {
+                TestOutputs.Capture(new RunResults { IntArg = intArg });
+            }
+
+            public void DefaultNullableInt(int? intArg = 1)
+            {
+                TestOutputs.Capture(new RunResults { IntArg = intArg });
+            }
+
+            public void DefaultInt(int intArg = 1)
+            {
+                TestOutputs.Capture(new RunResults { IntArg = intArg });
+            }
+        }
+
+        private class RunResults
+        {
+            public string StringArg { get; set; }
+            public Uri UriArg { get; set; }
+            public int? IntArg { get; set; }
+        }
+    }
+}

--- a/CommandDotNet.Tests/Utils/TestOutputs.cs
+++ b/CommandDotNet.Tests/Utils/TestOutputs.cs
@@ -5,17 +5,17 @@ namespace CommandDotNet.Tests.Utils
 {
     public class TestOutputs
     {
-        private Dictionary<Type, object> _inputs = new Dictionary<Type, object>();
+        public Dictionary<Type, object> Outputs { get; } = new Dictionary<Type, object>();
 
         public void Capture(object value)
         {
             // arguments should only be captured once.  don't allow overwrites.
-            _inputs.Add(value.GetType(), value);
+            Outputs.Add(value.GetType(), value);
         }
 
         public object Get(Type type)
         {
-            return _inputs.GetValueOrDefault(type);
+            return Outputs.GetValueOrDefault(type);
         }
 
         public T Get<T>()

--- a/CommandDotNet/Extensions/ObjectExtensions.cs
+++ b/CommandDotNet/Extensions/ObjectExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CommandDotNet.Extensions
+{
+    internal static class ObjectExtensions
+    {
+        internal static bool IsNullValue(this object obj)
+        {
+            return obj == null || obj == DBNull.Value;
+        }
+    }
+}

--- a/CommandDotNet/HelpGeneration/DetailedHelpTextProvider.cs
+++ b/CommandDotNet/HelpGeneration/DetailedHelpTextProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using CommandDotNet.Extensions;
 using CommandDotNet.MicrosoftCommandLineUtils;
 using CommandDotNet.Models;
 
@@ -117,12 +118,10 @@ namespace CommandDotNet.HelpGeneration
                     }));
                     
                     //default value
-                    optionsBuilder.Append(RenderParameter(options, commandOption, o =>
-                    {
-                        if(o.DefaultValue != DBNull.Value)
-                            return $"[{o.DefaultValue.ToString()}]";
-                        return null;
-                    }));
+                    optionsBuilder.Append(RenderParameter(options, commandOption, o => 
+                        o.DefaultValue.IsNullValue() 
+                            ? null 
+                            : $"[{o.DefaultValue.ToString()}]"));
 
                     //description
                     optionsBuilder.Append(string.IsNullOrEmpty(commandOption.Description)? null: $"{Environment.NewLine}  {commandOption.Description}");
@@ -173,11 +172,9 @@ namespace CommandDotNet.HelpGeneration
                     
                     //default value
                     argumentsBuilder.Append(RenderParameter(arguments, commandArgument, arg =>
-                    {
-                        if(arg.DefaultValue != DBNull.Value)
-                            return $"[{arg.DefaultValue.ToString()}]";
-                        return null;
-                    }));
+                        arg.DefaultValue.IsNullValue()
+                            ? null
+                            : $"[{arg.DefaultValue.ToString()}]"));
 
                     //description
                     argumentsBuilder.Append(string.IsNullOrEmpty(commandArgument.Description) ? null : $"{Environment.NewLine}  {commandArgument.Description}");

--- a/CommandDotNet/ValueMachine.cs
+++ b/CommandDotNet/ValueMachine.cs
@@ -31,7 +31,7 @@ namespace CommandDotNet
             }
 
             //when value not present but method parameter has a default value defined
-            if (argumentInfo.DefaultValue != DBNull.Value && argumentInfo.DefaultValue != null)
+            if (!argumentInfo.DefaultValue.IsNullValue())
             {
                 //use default parameter or property value
                 return argumentInfo.DefaultValue;
@@ -46,7 +46,7 @@ namespace CommandDotNet
             if (!_appSettings.PromptForArgumentsIfNotProvided
                 || !(argumentInfo is CommandParameterInfo parameterInfo)
                 || parameterInfo.ValueInfo.HasValue
-                || parameterInfo.DefaultValue != DBNull.Value)
+                || !parameterInfo.DefaultValue.IsNullValue())
             {
                 return;
             }

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ C# method for the same would look like
 ```c#
 public void Delete(
     string fileName, 
-    bool safely, 
+    [Option]bool safely, 
     [Option]string time = "Now")
 ```
 


### PR DESCRIPTION
Added OutputsStrict test option to assert no
unexpected methods were called.

![image](https://user-images.githubusercontent.com/103345/58472198-a4d63280-813d-11e9-8c88-1782bfe43611.png)
