### PR TITLE
create test default for AppSettings w/ Version disabled

### DIFF
--- a/CommandDotNet.Tests/CommandDotNet.Tests.csproj
+++ b/CommandDotNet.Tests/CommandDotNet.Tests.csproj
@@ -22,4 +22,7 @@
   <ItemGroup>
     <Content Include="TestCases/**/*" CopyToOutputDirectory="Always" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Parsing\" />
+  </ItemGroup>
 </Project>

--- a/CommandDotNet.Tests/FeatureTests/Arguments/AppsSettings_BoolMode.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/AppsSettings_BoolMode.cs
@@ -8,10 +8,11 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class AppsSettings_BoolMode : ScenarioTestBase<AppsSettings_BoolMode>
     {
-        private static AppSettings ImplicitBasicHelp = new AppSettings { BooleanMode = BooleanMode.Implicit, Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings ImplicitDetailedHelp = new AppSettings { BooleanMode = BooleanMode.Implicit, Help = { TextStyle = HelpTextStyle.Detailed } };
-        private static AppSettings ExplicitBasicHelp = new AppSettings { BooleanMode = BooleanMode.Explicit, Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings ExplicitDetailedHelp = new AppSettings { BooleanMode = BooleanMode.Explicit, Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings ImplicitBasicHelp = TestAppSettings.BasicHelp.Clone(a => a.BooleanMode = BooleanMode.Implicit);
+        private static AppSettings ImplicitDetailedHelp = TestAppSettings.DetailedHelp.Clone(a => a.BooleanMode = BooleanMode.Implicit);
+
+        private static AppSettings ExplicitBasicHelp = TestAppSettings.BasicHelp.Clone(a => a.BooleanMode = BooleanMode.Explicit);
+        private static AppSettings ExplicitDetailedHelp = TestAppSettings.DetailedHelp.Clone(a => a.BooleanMode = BooleanMode.Explicit);
 
         public AppsSettings_BoolMode(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/DefaultArgumentMode.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/DefaultArgumentMode.cs
@@ -7,18 +7,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class DefaultArgumentMode : ScenarioTestBase<DefaultArgumentMode>
     {
-        private static readonly AppSettings OperandMode = new AppSettings
-        {
-            MethodArgumentMode = ArgumentMode.Parameter,
-            Help = { TextStyle = HelpTextStyle.Basic },
-            EnableVersionOption = false
-        };
-        private static readonly AppSettings OptionMode = new AppSettings
-        {
-            MethodArgumentMode = ArgumentMode.Option, 
-            Help = { TextStyle = HelpTextStyle.Basic },
-            EnableVersionOption = false
-        };
+        private static readonly AppSettings OperandMode = TestAppSettings.BasicHelp.Clone(a => a.MethodArgumentMode = ArgumentMode.Parameter);
+        private static readonly AppSettings OptionMode = TestAppSettings.BasicHelp.Clone(a => a.MethodArgumentMode = ArgumentMode.Option);
 
         public DefaultArgumentMode(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/MixedDefinedAs_MethodParamsAndArgModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/MixedDefinedAs_MethodParamsAndArgModel.cs
@@ -9,8 +9,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class MixedDefinedAs_MethodParamsAndArgModel : ScenarioTestBase<MixedDefinedAs_MethodParamsAndArgModel>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public MixedDefinedAs_MethodParamsAndArgModel(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/NestedArgModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/NestedArgModel.cs
@@ -8,8 +8,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class NestedArgModel : ScenarioTestBase<NestedArgModel>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public NestedArgModel(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_Defaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsArgModel_Defaults : ScenarioTestBase<Operands_DefinedAsArgModel_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsArgModel_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_NoDefaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsArgModel_NoDefaults : ScenarioTestBase<Operands_DefinedAsArgModel_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}};
-        private static AppSettings DetailedHelp = new AppSettings {Help = {TextStyle = HelpTextStyle.Detailed}};
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsArgModel_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_Defaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsMethodParams_Defaults : ScenarioTestBase<Operands_DefinedAsMethodParams_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsMethodParams_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_NoDefaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsMethodParams_NoDefaults : ScenarioTestBase<Operands_DefinedAsMethodParams_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}};
-        private static AppSettings DetailedHelp = new AppSettings {Help = {TextStyle = HelpTextStyle.Detailed}};
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsMethodParams_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_Defaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsArgModel_Defaults : ScenarioTestBase<Options_DefinedAsArgModel_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsArgModel_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_NoDefaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsArgModel_NoDefaults : ScenarioTestBase<Options_DefinedAsArgModel_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsArgModel_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_Defaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsMethodParams_Defaults : ScenarioTestBase<Options_DefinedAsMethodParams_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsMethodParams_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_NoDefaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsMethodParams_NoDefaults : ScenarioTestBase<Options_DefinedAsMethodParams_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}};
-        private static AppSettings DetailedHelp = new AppSettings {Help = {TextStyle = HelpTextStyle.Detailed}};
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsMethodParams_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/ConstructorOptions.cs
+++ b/CommandDotNet.Tests/FeatureTests/ConstructorOptions.cs
@@ -23,13 +23,10 @@ namespace CommandDotNet.Tests.FeatureTests
 
 Options:
 
-  -v | --version
-  Show version information
-
   -h | --help
   Show help information
 
-  --rootOpt         <TEXT>
+  --rootOpt      <TEXT>
 
 
 Commands:

--- a/CommandDotNet.Tests/FeatureTests/ConstructorOptionsInherited.cs
+++ b/CommandDotNet.Tests/FeatureTests/ConstructorOptionsInherited.cs
@@ -23,13 +23,10 @@ namespace CommandDotNet.Tests.FeatureTests
 
 Options:
 
-  -v | --version
-  Show version information
-
   -h | --help
   Show help information
 
-  --rootOpt         <TEXT>
+  --rootOpt      <TEXT>
 
 
 Commands:

--- a/CommandDotNet.Tests/FeatureTests/NestedCommand.cs
+++ b/CommandDotNet.Tests/FeatureTests/NestedCommand.cs
@@ -29,9 +29,6 @@ namespace CommandDotNet.Tests.FeatureTests
 
 Options:
 
-  -v | --version
-  Show version information
-
   -h | --help
   Show help information
 

--- a/CommandDotNet.Tests/FeatureTests/VersionOption.cs
+++ b/CommandDotNet.Tests/FeatureTests/VersionOption.cs
@@ -6,8 +6,8 @@ namespace CommandDotNet.Tests.FeatureTests
 {
     public class VersionOption : ScenarioTestBase<VersionOption>
     {
-        private static AppSettings VersionEnabledBasicHelp = new AppSettings { EnableVersionOption = true, Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings VersionEnabledDetailedHelp = new AppSettings { EnableVersionOption = true, Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings VersionEnabledBasicHelp = TestAppSettings.BasicHelp.Clone(a => a.EnableVersionOption = true);
+        private static AppSettings VersionEnabledDetailedHelp = TestAppSettings.DetailedHelp.Clone(a => a.EnableVersionOption = true);
         private static AppSettings VersionDisabled = new AppSettings { EnableVersionOption = false };
 
         public VersionOption(ITestOutputHelper output) : base(output)

--- a/CommandDotNet.Tests/ScenarioFramework/ScenarioTestBase.cs
+++ b/CommandDotNet.Tests/ScenarioFramework/ScenarioTestBase.cs
@@ -40,8 +40,8 @@ namespace CommandDotNet.Tests.ScenarioFramework
             {
                 throw new Exception($"test class static property `{scenarioPropName}` ({scenariosRaw?.GetType()}) must implement {typeof(IEnumerable<IScenario>)}");
             }
-
-            return new ScenarioTestData(scenarios, new AppSettings());
+            
+            return new ScenarioTestData(scenarios, TestAppSettings.TestDefault);
         }
 
         public ScenarioTestBase(ITestOutputHelper output)

--- a/CommandDotNet.Tests/ScenarioFramework/XunitTestExtensions.cs
+++ b/CommandDotNet.Tests/ScenarioFramework/XunitTestExtensions.cs
@@ -12,7 +12,7 @@ namespace CommandDotNet.Tests.ScenarioFramework
         /// When false, test runs always pass but skipped tests with no theories will count as 1 test, making hard to identify
         /// actual skipped tests
         /// </summary>
-        private const bool DisableEmptyScenario = true;
+        private const bool DisableEmptyScenario = false;
 
         public static IEnumerable<object[]> ToObjectArrays<T>(this IEnumerable<T> items)
         {

--- a/CommandDotNet.Tests/TestAppSettings.cs
+++ b/CommandDotNet.Tests/TestAppSettings.cs
@@ -1,0 +1,26 @@
+using System;
+using CommandDotNet.Models;
+using CommandDotNet.Tests.Utils;
+
+namespace CommandDotNet.Tests
+{
+    public static class TestAppSettings
+    {
+        /// <summary>
+        /// version is a feature that's enabled for default. 
+        /// disabling it for tests reduces the noise in help expectations
+        /// and prevents tight coupling to the feature
+        /// </summary>
+        public static AppSettings TestDefault => new AppSettings{EnableVersionOption = false};
+        
+        public static AppSettings BasicHelp => new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}, EnableVersionOption = false};
+        public static AppSettings DetailedHelp => new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed }, EnableVersionOption = false };
+
+        public static AppSettings Clone(this AppSettings appSettings, Action<AppSettings> modify)
+        {
+            var clone = appSettings.Copy();
+            modify(clone);
+            return clone;
+        }
+    }
+}

--- a/CommandDotNet.Tests/Utils/AppRunnerTestExtensions.cs
+++ b/CommandDotNet.Tests/Utils/AppRunnerTestExtensions.cs
@@ -14,7 +14,7 @@ namespace CommandDotNet.Tests.Utils
         public static AppRunnerResult RunAppInMem(this Type appType, string[] args, AppSettings appSettings = null)
         {
             var type = typeof(AppRunner<>).MakeGenericType(appType);
-            var runner = Activator.CreateInstance(type, appSettings ?? new AppSettings());
+            var runner = Activator.CreateInstance(type, appSettings ?? TestAppSettings.TestDefault);
 
             var runInMemMethod = typeof(AppRunnerTestExtensions)
                 .GetMethod("RunInMem")

--- a/CommandDotNet.Tests/Utils/ObjectExtensions.cs
+++ b/CommandDotNet.Tests/Utils/ObjectExtensions.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CommandDotNet.Tests.Utils
+{
+    public static class ObjectExtensions
+    {
+        // copied from https://github.com/Burtsev-Alexey/net-object-deep-copy/blob/master/ObjectExtensions.cs
+
+        private static readonly MethodInfo CloneMethod = typeof(Object).GetMethod("MemberwiseClone", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        private static bool IsPrimitive(this Type type)
+        {
+            if (type == typeof(String)) return true;
+            return (type.IsValueType & type.IsPrimitive);
+        }
+        public static T Copy<T>(this T originalObject)
+        {
+            return (T)InternalCopy(originalObject, new Dictionary<Object, Object>(new ReferenceEqualityComparer()));
+        }
+        private static Object InternalCopy(Object originalObject, IDictionary<Object, Object> visited)
+        {
+            if (originalObject == null) return null;
+            var typeToReflect = originalObject.GetType();
+            if (IsPrimitive(typeToReflect)) return originalObject;
+            if (visited.ContainsKey(originalObject)) return visited[originalObject];
+            if (typeof(Delegate).IsAssignableFrom(typeToReflect)) return null;
+            var cloneObject = CloneMethod.Invoke(originalObject, null);
+            if (typeToReflect.IsArray)
+            {
+                var arrayType = typeToReflect.GetElementType();
+                if (IsPrimitive(arrayType) == false)
+                {
+                    Array clonedArray = (Array)cloneObject;
+                    clonedArray.ForEach((array, indices) => array.SetValue(InternalCopy(clonedArray.GetValue(indices), visited), indices));
+                }
+
+            }
+            visited.Add(originalObject, cloneObject);
+            CopyFields(originalObject, visited, cloneObject, typeToReflect);
+            RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect);
+            return cloneObject;
+        }
+
+        private static void RecursiveCopyBaseTypePrivateFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect)
+        {
+            if (typeToReflect.BaseType != null)
+            {
+                RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect.BaseType);
+                CopyFields(originalObject, visited, cloneObject, typeToReflect.BaseType, BindingFlags.Instance | BindingFlags.NonPublic, info => info.IsPrivate);
+            }
+        }
+
+        private static void CopyFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect, BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy, Func<FieldInfo, bool> filter = null)
+        {
+            foreach (FieldInfo fieldInfo in typeToReflect.GetFields(bindingFlags))
+            {
+                if (filter != null && filter(fieldInfo) == false) continue;
+                if (IsPrimitive(fieldInfo.FieldType)) continue;
+                var originalFieldValue = fieldInfo.GetValue(originalObject);
+                var clonedFieldValue = InternalCopy(originalFieldValue, visited);
+                fieldInfo.SetValue(cloneObject, clonedFieldValue);
+            }
+        }
+
+        public static void ForEach(this Array array, Action<Array, int[]> action)
+        {
+            if (array.LongLength == 0) return;
+            ArrayTraverse walker = new ArrayTraverse(array);
+            do action(array, walker.Position);
+            while (walker.Step());
+        }
+        internal class ArrayTraverse
+        {
+            public int[] Position;
+            private int[] maxLengths;
+
+            public ArrayTraverse(Array array)
+            {
+                maxLengths = new int[array.Rank];
+                for (int i = 0; i < array.Rank; ++i)
+                {
+                    maxLengths[i] = array.GetLength(i) - 1;
+                }
+                Position = new int[array.Rank];
+            }
+
+            public bool Step()
+            {
+                for (int i = 0; i < Position.Length; ++i)
+                {
+                    if (Position[i] < maxLengths[i])
+                    {
+                        Position[i]++;
+                        for (int j = 0; j < i; j++)
+                        {
+                            Position[j] = 0;
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public class ReferenceEqualityComparer : EqualityComparer<Object>
+        {
+            public override bool Equals(object x, object y)
+            {
+                return ReferenceEquals(x, y);
+            }
+            public override int GetHashCode(object obj)
+            {
+                if (obj == null) return 0;
+                return obj.GetHashCode();
+            }
+        }
+    }
+}

--- a/CommandDotNet.sln.DotSettings
+++ b/CommandDotNet.sln.DotSettings
@@ -46,8 +46,8 @@
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=EE16825558C04D4E8B3239CB7817914C/Text/@EntryValue">&#xD;
     public class $FeatureTestName$ : ScenarioTestBase&lt;$FeatureTestName$&gt;&#xD;
     {&#xD;
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };&#xD;
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };&#xD;
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;&#xD;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;&#xD;
 &#xD;
         public $FeatureTestName$(ITestOutputHelper output) : base(output)&#xD;
         {&#xD;


### PR DESCRIPTION
- prevents tight coupling to the feature
- reduces the noise in help expectations