### PR TITLE
create test default for AppSettings w/ Version disabled

### DIFF
--- a/CommandDotNet.Tests/CommandDotNet.Tests.csproj
+++ b/CommandDotNet.Tests/CommandDotNet.Tests.csproj
@@ -22,4 +22,7 @@
   <ItemGroup>
     <Content Include="TestCases/**/*" CopyToOutputDirectory="Always" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Parsing\" />
+  </ItemGroup>
 </Project>

--- a/CommandDotNet.Tests/FeatureTests/Arguments/AppsSettings_BoolMode.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/AppsSettings_BoolMode.cs
@@ -8,10 +8,11 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class AppsSettings_BoolMode : ScenarioTestBase<AppsSettings_BoolMode>
     {
-        private static AppSettings ImplicitBasicHelp = new AppSettings { BooleanMode = BooleanMode.Implicit, Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings ImplicitDetailedHelp = new AppSettings { BooleanMode = BooleanMode.Implicit, Help = { TextStyle = HelpTextStyle.Detailed } };
-        private static AppSettings ExplicitBasicHelp = new AppSettings { BooleanMode = BooleanMode.Explicit, Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings ExplicitDetailedHelp = new AppSettings { BooleanMode = BooleanMode.Explicit, Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings ImplicitBasicHelp = TestAppSettings.BasicHelp.Clone(a => a.BooleanMode = BooleanMode.Implicit);
+        private static AppSettings ImplicitDetailedHelp = TestAppSettings.DetailedHelp.Clone(a => a.BooleanMode = BooleanMode.Implicit);
+
+        private static AppSettings ExplicitBasicHelp = TestAppSettings.BasicHelp.Clone(a => a.BooleanMode = BooleanMode.Explicit);
+        private static AppSettings ExplicitDetailedHelp = TestAppSettings.DetailedHelp.Clone(a => a.BooleanMode = BooleanMode.Explicit);
 
         public AppsSettings_BoolMode(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/DefaultArgumentMode.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/DefaultArgumentMode.cs
@@ -7,18 +7,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class DefaultArgumentMode : ScenarioTestBase<DefaultArgumentMode>
     {
-        private static readonly AppSettings OperandMode = new AppSettings
-        {
-            MethodArgumentMode = ArgumentMode.Parameter,
-            Help = { TextStyle = HelpTextStyle.Basic },
-            EnableVersionOption = false
-        };
-        private static readonly AppSettings OptionMode = new AppSettings
-        {
-            MethodArgumentMode = ArgumentMode.Option, 
-            Help = { TextStyle = HelpTextStyle.Basic },
-            EnableVersionOption = false
-        };
+        private static readonly AppSettings OperandMode = TestAppSettings.BasicHelp.Clone(a => a.MethodArgumentMode = ArgumentMode.Parameter);
+        private static readonly AppSettings OptionMode = TestAppSettings.BasicHelp.Clone(a => a.MethodArgumentMode = ArgumentMode.Option);
 
         public DefaultArgumentMode(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/MixedDefinedAs_MethodParamsAndArgModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/MixedDefinedAs_MethodParamsAndArgModel.cs
@@ -9,8 +9,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class MixedDefinedAs_MethodParamsAndArgModel : ScenarioTestBase<MixedDefinedAs_MethodParamsAndArgModel>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public MixedDefinedAs_MethodParamsAndArgModel(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/NestedArgModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/NestedArgModel.cs
@@ -8,8 +8,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class NestedArgModel : ScenarioTestBase<NestedArgModel>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public NestedArgModel(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_Defaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsArgModel_Defaults : ScenarioTestBase<Operands_DefinedAsArgModel_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsArgModel_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_NoDefaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsArgModel_NoDefaults : ScenarioTestBase<Operands_DefinedAsArgModel_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}};
-        private static AppSettings DetailedHelp = new AppSettings {Help = {TextStyle = HelpTextStyle.Detailed}};
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsArgModel_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_Defaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsMethodParams_Defaults : ScenarioTestBase<Operands_DefinedAsMethodParams_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsMethodParams_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsMethodParams_NoDefaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Operands_DefinedAsMethodParams_NoDefaults : ScenarioTestBase<Operands_DefinedAsMethodParams_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}};
-        private static AppSettings DetailedHelp = new AppSettings {Help = {TextStyle = HelpTextStyle.Detailed}};
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Operands_DefinedAsMethodParams_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_Defaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsArgModel_Defaults : ScenarioTestBase<Options_DefinedAsArgModel_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsArgModel_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_NoDefaults.cs
@@ -11,8 +11,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsArgModel_NoDefaults : ScenarioTestBase<Options_DefinedAsArgModel_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsArgModel_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_Defaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsMethodParams_Defaults : ScenarioTestBase<Options_DefinedAsMethodParams_Defaults>
     {
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsMethodParams_Defaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_NoDefaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsMethodParams_NoDefaults.cs
@@ -12,8 +12,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
     public class Options_DefinedAsMethodParams_NoDefaults : ScenarioTestBase<Options_DefinedAsMethodParams_NoDefaults>
     {
-        private static AppSettings BasicHelp = new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}};
-        private static AppSettings DetailedHelp = new AppSettings {Help = {TextStyle = HelpTextStyle.Detailed}};
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
         public Options_DefinedAsMethodParams_NoDefaults(ITestOutputHelper output) : base(output)
         {

--- a/CommandDotNet.Tests/FeatureTests/ConstructorOptions.cs
+++ b/CommandDotNet.Tests/FeatureTests/ConstructorOptions.cs
@@ -23,13 +23,10 @@ namespace CommandDotNet.Tests.FeatureTests
 
 Options:
 
-  -v | --version
-  Show version information
-
   -h | --help
   Show help information
 
-  --rootOpt         <TEXT>
+  --rootOpt      <TEXT>
 
 
 Commands:

--- a/CommandDotNet.Tests/FeatureTests/ConstructorOptionsInherited.cs
+++ b/CommandDotNet.Tests/FeatureTests/ConstructorOptionsInherited.cs
@@ -23,13 +23,10 @@ namespace CommandDotNet.Tests.FeatureTests
 
 Options:
 
-  -v | --version
-  Show version information
-
   -h | --help
   Show help information
 
-  --rootOpt         <TEXT>
+  --rootOpt      <TEXT>
 
 
 Commands:

--- a/CommandDotNet.Tests/FeatureTests/NestedCommand.cs
+++ b/CommandDotNet.Tests/FeatureTests/NestedCommand.cs
@@ -29,9 +29,6 @@ namespace CommandDotNet.Tests.FeatureTests
 
 Options:
 
-  -v | --version
-  Show version information
-
   -h | --help
   Show help information
 

--- a/CommandDotNet.Tests/FeatureTests/VersionOption.cs
+++ b/CommandDotNet.Tests/FeatureTests/VersionOption.cs
@@ -6,8 +6,8 @@ namespace CommandDotNet.Tests.FeatureTests
 {
     public class VersionOption : ScenarioTestBase<VersionOption>
     {
-        private static AppSettings VersionEnabledBasicHelp = new AppSettings { EnableVersionOption = true, Help = { TextStyle = HelpTextStyle.Basic } };
-        private static AppSettings VersionEnabledDetailedHelp = new AppSettings { EnableVersionOption = true, Help = { TextStyle = HelpTextStyle.Detailed } };
+        private static AppSettings VersionEnabledBasicHelp = TestAppSettings.BasicHelp.Clone(a => a.EnableVersionOption = true);
+        private static AppSettings VersionEnabledDetailedHelp = TestAppSettings.DetailedHelp.Clone(a => a.EnableVersionOption = true);
         private static AppSettings VersionDisabled = new AppSettings { EnableVersionOption = false };
 
         public VersionOption(ITestOutputHelper output) : base(output)

--- a/CommandDotNet.Tests/ScenarioFramework/ScenarioTestBase.cs
+++ b/CommandDotNet.Tests/ScenarioFramework/ScenarioTestBase.cs
@@ -40,8 +40,8 @@ namespace CommandDotNet.Tests.ScenarioFramework
             {
                 throw new Exception($"test class static property `{scenarioPropName}` ({scenariosRaw?.GetType()}) must implement {typeof(IEnumerable<IScenario>)}");
             }
-
-            return new ScenarioTestData(scenarios, new AppSettings());
+            
+            return new ScenarioTestData(scenarios, TestAppSettings.TestDefault);
         }
 
         public ScenarioTestBase(ITestOutputHelper output)

--- a/CommandDotNet.Tests/TestAppSettings.cs
+++ b/CommandDotNet.Tests/TestAppSettings.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using CommandDotNet.Models;
+using CommandDotNet.Tests.Utils;
+using CommandDotNet.TypeDescriptors;
+
+namespace CommandDotNet.Tests
+{
+    public static class TestAppSettings
+    {
+        /// <summary>
+        /// version is a feature that's enabled for default. 
+        /// disabling it for tests reduces the noise in help expectations
+        /// and prevents tight coupling to the feature
+        /// </summary>
+        public static AppSettings TestDefault => new AppSettings{EnableVersionOption = false};
+        
+        public static AppSettings BasicHelp => new AppSettings{Help = {TextStyle = HelpTextStyle.Basic}, EnableVersionOption = false};
+        public static AppSettings DetailedHelp => new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed }, EnableVersionOption = false };
+
+        public static AppSettings Clone(this AppSettings original, Action<AppSettings> modify)
+        {
+            // var clone = appSettings.Copy();
+
+            var clone = new AppSettings();
+            Copy(original, clone);
+
+            clone.Help = new AppHelpSettings();
+            Copy(original.Help, clone.Help);
+
+            clone.ArgumentTypeDescriptors = new ArgumentTypeDescriptors(original.ArgumentTypeDescriptors);
+
+            modify(clone);
+            return clone;
+        }
+
+        private static void Copy<T>(T original, T clone)
+        {
+            var props = typeof(T)
+                .GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanWrite);
+
+            foreach (var prop in props)
+            {
+                prop.SetValue(clone, prop.GetValue(original));
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/Utils/AppRunnerTestExtensions.cs
+++ b/CommandDotNet.Tests/Utils/AppRunnerTestExtensions.cs
@@ -14,7 +14,7 @@ namespace CommandDotNet.Tests.Utils
         public static AppRunnerResult RunAppInMem(this Type appType, string[] args, AppSettings appSettings = null)
         {
             var type = typeof(AppRunner<>).MakeGenericType(appType);
-            var runner = Activator.CreateInstance(type, appSettings ?? new AppSettings());
+            var runner = Activator.CreateInstance(type, appSettings ?? TestAppSettings.TestDefault);
 
             var runInMemMethod = typeof(AppRunnerTestExtensions)
                 .GetMethod("RunInMem")

--- a/CommandDotNet.sln.DotSettings
+++ b/CommandDotNet.sln.DotSettings
@@ -46,8 +46,8 @@
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=EE16825558C04D4E8B3239CB7817914C/Text/@EntryValue">&#xD;
     public class $FeatureTestName$ : ScenarioTestBase&lt;$FeatureTestName$&gt;&#xD;
     {&#xD;
-        private static AppSettings BasicHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Basic } };&#xD;
-        private static AppSettings DetailedHelp = new AppSettings { Help = { TextStyle = HelpTextStyle.Detailed } };&#xD;
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;&#xD;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;&#xD;
 &#xD;
         public $FeatureTestName$(ITestOutputHelper output) : base(output)&#xD;
         {&#xD;

--- a/CommandDotNet/Models/AppSettings.cs
+++ b/CommandDotNet/Models/AppSettings.cs
@@ -58,7 +58,7 @@ namespace CommandDotNet.Models
             set => Help.TextStyle = value;
         }
         
-        public ArgumentTypeDescriptors ArgumentTypeDescriptors { get; } = new ArgumentTypeDescriptors();
+        public ArgumentTypeDescriptors ArgumentTypeDescriptors { get; internal set; } = new ArgumentTypeDescriptors();
         
         internal IHelpProvider CustomHelpProvider { get; set; }
 
@@ -66,6 +66,5 @@ namespace CommandDotNet.Models
         
         internal TextWriter Out { get; set; } = Console.Out;
         internal TextWriter Error { get; set; } = Console.Error;
-
     }
 }

--- a/CommandDotNet/TypeDescriptors/ArgumentTypeDescriptors.cs
+++ b/CommandDotNet/TypeDescriptors/ArgumentTypeDescriptors.cs
@@ -26,7 +26,17 @@ namespace CommandDotNet.TypeDescriptors
             
             new ComponentModelTypeDescriptor()
         };
-        
+
+        public ArgumentTypeDescriptors()
+        {
+        }
+
+        internal ArgumentTypeDescriptors(ArgumentTypeDescriptors origin)
+        {
+            _customDescriptors = new List<IArgumentTypeDescriptor>(origin._customDescriptors);
+            _defaultDescriptors = new List<IArgumentTypeDescriptor>(origin._defaultDescriptors);
+        }
+
         public void Add(IArgumentTypeDescriptor argumentTypeDescriptor)
         {
             _customDescriptors.Add(argumentTypeDescriptor);


### PR DESCRIPTION
- prevents tight coupling to the feature
- reduces the noise in help expectations