### PR TITLE
introduce echo-args in example to test shell arg parsing

### DIFF
--- a/CommandDotNet.Example/Program.cs
+++ b/CommandDotNet.Example/Program.cs
@@ -1,4 +1,6 @@
-﻿using CommandDotNet.Attributes;
+﻿using System;
+using System.Linq;
+using CommandDotNet.Attributes;
 using CommandDotNet.Example.Issues;
 using CommandDotNet.Models;
 
@@ -8,6 +10,14 @@ namespace CommandDotNet.Example
     {
         static int Main(string[] args)
         {
+            if (args.FirstOrDefault() == "echo-args")
+            {
+                foreach (var arg in args.Skip(1))
+                {
+                    Console.Out.WriteLine(arg);
+                }
+                return 0;
+            }
             // return Run<GitApplication>(args);
             return Run<Examples>(args);
         }


### PR DESCRIPTION
to examine how different shells parse quoted strings

shell - git bash on Win 10
![image](https://user-images.githubusercontent.com/103345/59293036-400af400-8c76-11e9-9216-e1c9e3d76aec.png)

shell - cmd.exe on Win 10
![image](https://user-images.githubusercontent.com/103345/59293088-62047680-8c76-11e9-9314-80de9904ca9a.png)


this is how the arguments are passed into our .net process.