### PR TITLE
Fix default list values in Detailed Help

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_Defaults.cs
@@ -42,7 +42,7 @@ Options:
             });
         }
 
-        [Fact(Skip = "Help should not contain default value as [System.Collections.Generic.List`1[System.String]]")]
+        [Fact]
         public void SampleTypes_DetailedHelp_IncludesAll()
         {
             Verify(new Given<OperandsDefaults>
@@ -67,7 +67,7 @@ Arguments:
 
   ObjectArg                   <URI>          [http://google.com/]
 
-  StringListArg (Multiple)    <TEXT>         [System.Collections.Generic.List`1[System.String]]
+  StringListArg (Multiple)    <TEXT>         [blue,red]
 
 
 Options:
@@ -94,7 +94,7 @@ Options:
             });
         }
 
-        [Fact(Skip = "Help should not contain default value as [System.Collections.Generic.List`1[System.Int32]]")]
+        [Fact]
         public void StructList_DetailedHelp_IncludesList()
         {
             Verify(new Given<OperandsDefaults>
@@ -105,7 +105,7 @@ Options:
 
 Arguments:
 
-  StructListArg (Multiple)    <NUMBER>    [System.Collections.Generic.List`1[System.Int32]]
+  StructListArg (Multiple)    <NUMBER>    [3,4]
 
 
 Options:
@@ -132,7 +132,7 @@ Options:
             });
         }
 
-        [Fact(Skip = "Help should not contain default value as [System.Collections.Generic.List`1[System.DayOfWeek]]")]
+        [Fact]
         public void EnumList_DetailedHelp_IncludesList()
         {
             Verify(new Given<OperandsDefaults>
@@ -143,7 +143,7 @@ Options:
 
 Arguments:
 
-  EnumListArg (Multiple)    <DAYOFWEEK>    [System.Collections.Generic.List`1[System.DayOfWeek]]
+  EnumListArg (Multiple)    <DAYOFWEEK>    [Monday,Tuesday]
   Allowed values: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday
 
 
@@ -171,7 +171,7 @@ Options:
             });
         }
 
-        [Fact(Skip = "Help should not contain default value as [System.Collections.Generic.List`1[System.Uri]]")]
+        [Fact]
         public void ObjectList_DetailedHelp_IncludesList()
         {
             Verify(new Given<OperandsDefaults>
@@ -182,7 +182,7 @@ Options:
 
 Arguments:
 
-  ObjectListArg (Multiple)    <URI>    [System.Collections.Generic.List`1[System.Uri]]
+  ObjectListArg (Multiple)    <URI>    [http://github.com/,http://google.com/]
 
 
 Options:

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_Defaults.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_DefinedAsArgModel_Defaults.cs
@@ -43,7 +43,7 @@ Options:
             });
         }
 
-        [Fact(Skip = "Help should not contain default values as [System.Collections.Generic.List`1[...]]")]
+        [Fact]
         public void SampleTypes_DetailedHelp_IncludesAll()
         {
             Verify(new Given<OptionsDefaults>
@@ -57,8 +57,7 @@ Options:
   -h | --help
   Show help information
 
-  --BoolArg                     <BOOLEAN>      [True]
-  Allowed values: true, false
+  --BoolArg                                    [True]
 
   --StringArg                   <TEXT>         [lala]
 
@@ -71,14 +70,14 @@ Options:
 
   --ObjectArg                   <URI>          [http://google.com/]
 
-  --StringListArg (Multiple)    <TEXT>         [System.Collections.Generic.List`1[System.String]]
+  --StringListArg (Multiple)    <TEXT>         [blue,red]
 
-  --StructListArg (Multiple)    <NUMBER>       [System.Collections.Generic.List`1[System.Int32]]
+  --StructListArg (Multiple)    <NUMBER>       [3,4]
 
-  --EnumListArg (Multiple)      <DAYOFWEEK>    [System.Collections.Generic.List`1[System.DayOfWeek]]
+  --EnumListArg (Multiple)      <DAYOFWEEK>    [Monday,Tuesday]
   Allowed values: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday
 
-  --ObjectListArg (Multiple)    <URI>          [System.Collections.Generic.List`1[System.Uri]]" }
+  --ObjectListArg (Multiple)    <URI>          [http://github.com/,http://google.com/]" }
             });
         }
 

--- a/CommandDotNet/Extensions/EnumerableExtensions.cs
+++ b/CommandDotNet/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CommandDotNet.Extensions
+{
+    internal static class EnumerableExtensions
+    {
+        internal static string ToCsv<T>(this IEnumerable<T> items, string separator = ",")
+        {
+            return string.Join(separator, items);
+        }
+
+        /// <summary>Joins the object.ToString() into a sorted delimited string. Useful for logging.</summary>
+        public static string ToOrderedCsv<T>(this IEnumerable<T> enumerable, string separator = ",")
+        {
+            return enumerable
+                .Select(i => i?.ToString())
+                .ToOrderedCsv(separator);
+        }
+
+        /// <summary>Joins the string into a sorted delimited string. Useful for logging.</summary>
+        public static string ToOrderedCsv(this IEnumerable<string> enumerable, string separator = ",")
+        {
+            return enumerable.OrderBy(i => i).ToCsv(separator);
+        }
+
+        internal static string ToOrderedCsv(this IEnumerable items, string separator = ",")
+        {
+            return items.Cast<object>().ToOrderedCsv();
+        }
+    }
+}

--- a/CommandDotNet/StringExtensions.cs
+++ b/CommandDotNet/StringExtensions.cs
@@ -22,5 +22,15 @@ namespace CommandDotNet
                     return value;
             }
         }
+
+        public static bool IsNullOrEmpty(this string value)
+        {
+            return string.IsNullOrEmpty(value);
+        }
+
+        public static bool IsNullOrWhitespace(this string value)
+        {
+            return string.IsNullOrWhiteSpace(value);
+        }
     }
 }


### PR DESCRIPTION
ex: [System.Collections.Generic.List`1[System.String]]

is now: [blue,red]

also fixed issue where help was generating every segment
for an argument 2+{arg count} resulting in O(N²).

Typically not a big deal since arguments won't be big
numbers, but every bit counts when you want a fast
console app.