### PR TITLE
any type w/ a string ctor can be converted for arguments

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/Arguments/StringCtorObjectsAsArguments.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/StringCtorObjectsAsArguments.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using CommandDotNet.Attributes;
+using CommandDotNet.Models;
+using CommandDotNet.Tests.ScenarioFramework;
+using CommandDotNet.Tests.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Arguments
+{
+    public class StringCtorObjectsAsArguments : TestBase
+    {
+        private static AppSettings BasicHelp = TestAppSettings.BasicHelp;
+        private static AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
+
+        public StringCtorObjectsAsArguments(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void BasicHelp_Includes_StringCtorObjects()
+        {
+            Verify(new Given<App>
+            {
+                And = {AppSettings = BasicHelp},
+                WhenArgs = "Do -h",
+                Then = {Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+
+Arguments:
+  arg
+
+Options:
+  -h | --help  Show help information" }
+            });
+        }
+
+        [Fact]
+        public void BasicHelp_List_Includes_StringCtorObjects()
+        {
+            Verify(new Given<App>
+            {
+                And = { AppSettings = BasicHelp },
+                WhenArgs = "DoList -h",
+                Then = { Result = @"Usage: dotnet testhost.dll DoList [arguments] [options]
+
+Arguments:
+  args
+
+Options:
+  -h | --help  Show help information" }
+            });
+        }
+
+        [Fact]
+        public void DetailedHelp_Includes_StringCtorObjects()
+        {
+            Verify(new Given<App>
+            {
+                And = {AppSettings = DetailedHelp},
+                WhenArgs = "Do -h",
+                Then = {Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+
+Arguments:
+
+  arg    <STRINGCTOROBJECT>
+
+
+Options:
+
+  -h | --help
+  Show help information" }
+            });
+        }
+
+        [Fact]
+        public void DetailedHelp_List_Includes_StringCtorObjects()
+        {
+            Verify(new Given<App>
+            {
+                And = { AppSettings = DetailedHelp },
+                WhenArgs = "DoList -h",
+                Then = { Result = @"Usage: dotnet testhost.dll DoList [arguments] [options]
+
+Arguments:
+
+  args (Multiple)    <STRINGCTOROBJECT>
+
+
+Options:
+
+  -h | --help
+  Show help information" }
+            });
+        }
+
+        [Fact]
+        public void Exec_ConvertsStringToObject()
+        {
+            Verify(new Given<App>
+            {
+                WhenArgs = "DoList some-value another-value",
+                Then =
+                {
+                    Outputs =
+                    {
+                        new List<StringCtorObject>
+                        {
+                            new StringCtorObject("some-value"),
+                            new StringCtorObject("another-value")
+                        }
+                    }
+                }
+            });
+        }
+
+        [Fact]
+        public void Exec_List_ConvertsStringToObject()
+        {
+            Verify(new Given<App>
+            {
+                WhenArgs = "Do some-value",
+                Then = { Outputs = { new StringCtorObject("some-value") } }
+            });
+        }
+
+        public class App
+        {
+            [InjectProperty]
+            public TestOutputs TestOutputs { get; set; }
+
+            public void Do(StringCtorObject arg)
+            {
+                TestOutputs.Capture(arg);
+            }
+
+            public void DoList(List<StringCtorObject> args)
+            {
+                TestOutputs.Capture(args);
+            }
+        }
+
+        public class StringCtorObject
+        {
+            public string Value { get; }
+
+            public StringCtorObject(string value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/CommandDotNet/TypeDescriptors/ArgumentTypeDescriptors.cs
+++ b/CommandDotNet/TypeDescriptors/ArgumentTypeDescriptors.cs
@@ -24,7 +24,8 @@ namespace CommandDotNet.TypeDescriptors
             new DelegatedTypeDescriptor<decimal>(Constants.TypeDisplayNames.DecimalNumber, (a, v) => decimal.Parse(v, CultureInfo.InvariantCulture)),
             new DelegatedTypeDescriptor<double>(Constants.TypeDisplayNames.DoubleNumber, (a, v) => double.Parse(v, CultureInfo.InvariantCulture)),
             
-            new ComponentModelTypeDescriptor()
+            new ComponentModelTypeDescriptor(),
+            new StringCtorTypeDescriptor()
         };
 
         public ArgumentTypeDescriptors()

--- a/CommandDotNet/TypeDescriptors/StringCtorTypeDescriptor.cs
+++ b/CommandDotNet/TypeDescriptors/StringCtorTypeDescriptor.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using CommandDotNet.Models;
+
+namespace CommandDotNet.TypeDescriptors
+{
+    public class StringCtorTypeDescriptor : IArgumentTypeDescriptor
+    {
+        private static readonly ConcurrentDictionary<Type, Converter> cache = new ConcurrentDictionary<Type, Converter>();
+
+        public bool CanSupport(Type type)
+        {
+            return GetConverter(type).CanConvert;
+        }
+
+        public string GetDisplayName(ArgumentInfo argumentInfo)
+        {
+            return argumentInfo.UnderlyingType.Name;
+        }
+
+        public object ParseString(ArgumentInfo argumentInfo, string value)
+        {
+            var typeConverter = argumentInfo.IsMultipleType
+                ? GetConverter(argumentInfo.UnderlyingType)
+                : GetConverter(argumentInfo.Type);
+            return typeConverter.StringConstructor.Invoke(new []{ value });
+        }
+
+        private static Converter GetConverter(Type type)
+        {
+            return cache.GetOrAdd(type, t =>
+            {
+                var stringCtor = type.GetConstructors().FirstOrDefault(c =>
+                {
+                    var parameterInfos = c.GetParameters();
+                    return parameterInfos.Length == 1 && parameterInfos.First().ParameterType == typeof(string);
+                });
+
+                return new Converter(stringCtor);
+            });
+        }
+
+        private class Converter
+        {
+            public bool CanConvert => StringConstructor != null;
+            public ConstructorInfo StringConstructor { get; }
+
+            public Converter(ConstructorInfo stringConstructor)
+            {
+                StringConstructor = stringConstructor;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ dotnet example.dll LaunchRocket mars earth jupiter
 
 ## Supported parameter types
 
-Supports all types where a TypeConverter is defined that can convert from a string.  Includes, but not limited to:
+Supports all types with a string constructor or where a TypeConverter is defined that can convert from a string.  Includes, but not limited to:
 
 - `string`
 - `char`
@@ -579,6 +579,8 @@ Supports all types where a TypeConverter is defined that can convert from a stri
 - `double`
 - `Guid`
 - `Uri`
+- `FileInfo`
+- `DirectoryInfo`
 
 Also supports `List<T>` and `Nullable<T>` where T can be converted from string.
 


### PR DESCRIPTION
@bilal-fazlani I got this idea from https://github.com/dotnet/command-line-api.  Thanks to the TypeDescriptors, it's was 15 minutes of coding.   That repo may be the future but they're still some things, like subcommands, and operands have to be named.  

Anyway, this enables FileInfo, DirectoryInfo, etc as parameters types.  Pretty cool I think.