### PR TITLE
add System.CommandLine style directives

### DIFF
--- a/CommandDotNet.Example/Directives.cs
+++ b/CommandDotNet.Example/Directives.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CommandDotNet.Example
+{
+    internal static class Directives
+    {
+        public class DirectivesResult
+        {
+            public int? ExitCode { get; }
+
+            public DirectivesResult(int? exitCode = null)
+            {
+                ExitCode = exitCode;
+            }
+        }
+
+        public static DirectivesResult ProcessDirectives(ref string[] args)
+        {
+            var firstArg = args.FirstOrDefault();
+            if (firstArg == null)
+            {
+                return new DirectivesResult();
+            }
+
+            // adapted from https://github.com/dotnet/command-line-api directives
+
+            if (firstArg.Equals("[debug]", StringComparison.InvariantCultureIgnoreCase))
+            {
+                args = args.Skip(1).ToArray();
+                var process = Process.GetCurrentProcess();
+
+                var processId = process.Id;
+
+                Console.Out.WriteLine($"Attach your debugger to process {processId} ({process.ProcessName}).");
+
+                while (!Debugger.IsAttached)
+                {
+                    Task.Delay(500);
+                }
+            }
+            else if (firstArg.Equals("[parse]", StringComparison.InvariantCultureIgnoreCase))
+            {
+                foreach (var arg in args.Skip(1))
+                {
+                    Console.Out.WriteLine(arg);
+                }
+                return new DirectivesResult(0);
+            }
+
+
+            return new DirectivesResult();
+        }
+
+    }
+}

--- a/CommandDotNet.Example/Program.cs
+++ b/CommandDotNet.Example/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using CommandDotNet.Attributes;
+﻿using CommandDotNet.Attributes;
 using CommandDotNet.Example.Issues;
 using CommandDotNet.Models;
 
@@ -10,21 +8,19 @@ namespace CommandDotNet.Example
     {
         static int Main(string[] args)
         {
-            if (args.FirstOrDefault() == "echo-args")
+            var result = Directives.ProcessDirectives(ref args);
+            if (result.ExitCode.HasValue)
             {
-                foreach (var arg in args.Skip(1))
-                {
-                    Console.Out.WriteLine(arg);
-                }
-                return 0;
+                return result.ExitCode.Value;
             }
+
             // return Run<GitApplication>(args);
             return Run<Examples>(args);
         }
 
         private static int Run<TApp>(string[] args) where TApp : class
         {
-            AppRunner<TApp> appRunner = new AppRunner<TApp>(new AppSettings()
+            AppRunner<TApp> appRunner = new AppRunner<TApp>(new AppSettings
             {
                 Case = Case.KebabCase,
                 Help =
@@ -34,20 +30,20 @@ namespace CommandDotNet.Example
             });
             return appRunner.Run(args);
         }
-    }
 
-    public class Examples
-    {
-        [SubCommand]
-        public GitApplication GitApplication { get; set; }
-        
-        [SubCommand]
-        public ModelApp ModelApp { get; set; }
-        
-        [SubCommand]
-        public MyApplication MyApplication { get; set; }
+        public class Examples
+        {
+            [SubCommand]
+            public GitApplication GitApplication { get; set; }
 
-        [SubCommand]
-        public IssueApps IssueApps { get; set; }
+            [SubCommand]
+            public ModelApp ModelApp { get; set; }
+
+            [SubCommand]
+            public MyApplication MyApplication { get; set; }
+
+            [SubCommand]
+            public IssueApps IssueApps { get; set; }
+        }
     }
 }


### PR DESCRIPTION
[debug] will print the current process id and wait for
a debugger to attach

[parse] will print the args as parsed by the shell
this is not intended to be as feature rich as theirs
but just borrowing their naming convention