### PR TITLE
support '-?' for help

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/Help/GeneralHelpTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Help/GeneralHelpTests.cs
@@ -1,0 +1,42 @@
+using CommandDotNet.Tests.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Help
+{
+    public class GeneralHelpTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public GeneralHelpTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void QuestionMark_ShowsHelp()
+        {
+            var result = new AppRunner<App>().RunInMem("-?".SplitArgs(), _testOutputHelper);
+            result.OutputContains("Usage: dotnet testhost.dll [command]");
+        }
+
+        [Fact]
+        public void ShortName_ShowsHelp()
+        {
+            var result = new AppRunner<App>().RunInMem("-h".SplitArgs(), _testOutputHelper);
+            result.OutputContains("Usage: dotnet testhost.dll [command]");
+        }
+
+        [Fact]
+        public void LongName_ShowsHelp()
+        {
+            var result = new AppRunner<App>().RunInMem("--help".SplitArgs(), _testOutputHelper);
+            result.OutputContains("Usage: dotnet testhost.dll [command]");
+        }
+
+        public class App
+        {
+            public void Do(){ }
+        }
+    }
+}

--- a/CommandDotNet/ArgumentTemplate.cs
+++ b/CommandDotNet/ArgumentTemplate.cs
@@ -7,18 +7,15 @@ namespace CommandDotNet
     {
         public string Name { get; }
         public string ShortName { get; }
-        public string SymbolName { get; }
         public string TypeDisplayName { get; }
 
         public ArgumentTemplate(
             string name = null, 
-            string shortName = null, 
-            string symbolName = null, 
+            string shortName = null,
             string typeDisplayName = null)
         {
             Name = name;
             ShortName = shortName;
-            SymbolName = symbolName;
             TypeDisplayName = typeDisplayName;
         }
 
@@ -33,16 +30,7 @@ namespace CommandDotNet
                 else if (part.StartsWith("-"))
                 {
                     var optName = part.Substring(1);
-
-                    // If there is only one char and it is not an English letter, it is a symbol option (e.g. "-?")
-                    if (optName.Length == 1 && !IsEnglishLetter(optName[0]))
-                    {
-                        SymbolName = optName;
-                    }
-                    else
-                    {
-                        ShortName = optName;
-                    }
+                    ShortName = optName;
                 }
                 else if (part.StartsWith("<") && part.EndsWith(">"))
                 {
@@ -54,7 +42,7 @@ namespace CommandDotNet
                 }
             }
 
-            if (string.IsNullOrEmpty(Name) && string.IsNullOrEmpty(ShortName) && string.IsNullOrEmpty(SymbolName))
+            if (string.IsNullOrEmpty(Name) && string.IsNullOrEmpty(ShortName))
             {
                 throw new ArgumentException($"Invalid template pattern '{template}' Unable to determine the name of the argument. " +
                                             "provide either a symbol, short or long name following this pattern: -symbol|-short|--long", nameof(template));
@@ -79,13 +67,12 @@ namespace CommandDotNet
             }
 
             AppendIfNotNull("-", ShortName);
-            AppendIfNotNull("-", SymbolName);
             AppendIfNotNull("--", Name);
 
             if (sb.Length == 0)
             {
                 throw new Exception("Unable to generate template. " +
-                                    $"One of either {nameof(Name)}, {nameof(ShortName)} or {nameof(SymbolName)} must be specified");
+                                    $"One of either {nameof(Name)} or {nameof(ShortName)} must be specified");
             }
 
             return TypeDisplayName.IsNullOrWhitespace()

--- a/CommandDotNet/Help/HelpMiddleware.cs
+++ b/CommandDotNet/Help/HelpMiddleware.cs
@@ -17,7 +17,7 @@ namespace CommandDotNet.Help
 
         private static void AddHelpOption(BuildEvents.CommandCreatedEventArgs args)
         {
-            var option = new Option(Constants.HelpTemplate, ArgumentArity.Zero)
+            var option = new Option(Constants.HelpTemplate, ArgumentArity.Zero, aliases: new []{"?"})
             {
                 Description = "Show help information",
                 TypeInfo = new TypeInfo

--- a/CommandDotNet/IOption.cs
+++ b/CommandDotNet/IOption.cs
@@ -4,7 +4,6 @@
     {
         string Template { get; }
         string ShortName { get; }
-        string SymbolName { get; }
         bool Inherited { get; }
 
         /// <summary>True when option is help or version</summary>

--- a/CommandDotNet/Parsing/CommandParser.cs
+++ b/CommandDotNet/Parsing/CommandParser.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CommandDotNet.Execution;
-using CommandDotNet.Extensions;
 using CommandDotNet.Help;
 
 namespace CommandDotNet.Parsing
@@ -28,7 +27,6 @@ namespace CommandDotNet.Parsing
             {
                 var console = commandContext.AppSettings.Console;
                 console.Error.WriteLine(ex.Message);
-                ex.PrintStackTrace(console);
                 console.Error.WriteLine();
                 HelpMiddleware.Print(commandContext.AppSettings, ex.Command);
                 return Task.FromResult(1);


### PR DESCRIPTION
didn't add to the template because that is included
in the help output.

Removed Option.Symbol because it was only useful
for help and that's no longer necessary with the new
design