### PR TITLE
bring back Option.LongName then Option.Name=>Long??Short

### DIFF
--- a/CommandDotNet.Example/DocExamples/RocketLauncher.cs
+++ b/CommandDotNet.Example/DocExamples/RocketLauncher.cs
@@ -10,7 +10,7 @@ namespace CommandDotNet.Example.DocExamples
         { }
 
         public void LaunchRocket2([Option(
-            Name = "planet",
+            LongName = "planet",
             ShortName = "p",
             Description = "Name of the planet you wish the rocket to go")] string planetName)
         { }

--- a/CommandDotNet.Tests/FeatureTests/Arguments/BasicParseScenarios.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/BasicParseScenarios.cs
@@ -129,7 +129,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                 int x,
                 [Operand(Description = "the second operand")]
                 int y,
-                [Option(ShortName = "o", Name = "operator", Description = "the operation to apply")]
+                [Option(ShortName = "o", LongName = "operator", Description = "the operation to apply")]
                 string operation = "+")
             {
                 TestOutputs.Capture(new AddResults { X = x, Y = y, Op = operation });

--- a/CommandDotNet.Tests/FeatureTests/CaseTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/CaseTests.cs
@@ -70,7 +70,7 @@ namespace CommandDotNet.Tests.FeatureTests
                 return 10;
             }
 
-            public int Send([Option] string messageName, [Option(Name = "Sender")] string senderName,
+            public int Send([Option] string messageName, [Option(LongName = "Sender")] string senderName,
                 [Option(ShortName = "P")] int priority, [Option]int c)
             {
                 return messageName == "m" && senderName == "s" && priority == 3 && c == 4 ? 10 : 1;

--- a/CommandDotNet/ArgumentTemplate.cs
+++ b/CommandDotNet/ArgumentTemplate.cs
@@ -5,16 +5,16 @@ namespace CommandDotNet
 {
     public class ArgumentTemplate
     {
-        public string Name { get; }
+        public string LongName { get; }
         public string ShortName { get; }
         public string TypeDisplayName { get; }
 
         public ArgumentTemplate(
-            string name = null, 
+            string longName = null, 
             string shortName = null,
             string typeDisplayName = null)
         {
-            Name = name;
+            LongName = longName;
             ShortName = shortName;
             TypeDisplayName = typeDisplayName;
         }
@@ -25,7 +25,7 @@ namespace CommandDotNet
             {
                 if (part.StartsWith("--"))
                 {
-                    Name = part.Substring(2);
+                    LongName = part.Substring(2);
                 }
                 else if (part.StartsWith("-"))
                 {
@@ -42,7 +42,7 @@ namespace CommandDotNet
                 }
             }
 
-            if (string.IsNullOrEmpty(Name) && string.IsNullOrEmpty(ShortName))
+            if (LongName.IsNullOrWhitespace() && ShortName.IsNullOrWhitespace())
             {
                 throw new ArgumentException($"Invalid template pattern '{template}' Unable to determine the name of the argument. " +
                                             "provide either a symbol, short or long name following this pattern: -symbol|-short|--long", nameof(template));
@@ -67,12 +67,12 @@ namespace CommandDotNet
             }
 
             AppendIfNotNull("-", ShortName);
-            AppendIfNotNull("--", Name);
+            AppendIfNotNull("--", LongName);
 
             if (sb.Length == 0)
             {
                 throw new Exception("Unable to generate template. " +
-                                    $"One of either {nameof(Name)} or {nameof(ShortName)} must be specified");
+                                    $"One of either {nameof(LongName)} or {nameof(ShortName)} must be specified");
             }
 
             return TypeDisplayName.IsNullOrWhitespace()

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -81,7 +81,7 @@ namespace CommandDotNet.ClassModeling.Definitions
             var optionAttr = argumentDef.Attributes.GetCustomAttribute<OptionAttribute>();
             var argumentArity = ArgumentArity.Default(argumentDef.Type, GetOptionBooleanMode(argumentDef, executionConfig.AppSettings.BooleanMode, optionAttr));
             return new Option(
-                new ArgumentTemplate(optionAttr?.Name ?? argumentDef.Name, optionAttr?.ShortName).ToString(),
+                new ArgumentTemplate(optionAttr?.LongName ?? argumentDef.Name, optionAttr?.ShortName).ToString(),
                 argumentArity, customAttributeProvider: argumentDef.Attributes)
             {
                 Description = optionAttr?.Description,

--- a/CommandDotNet/Help/BasicHelpTextProvider.cs
+++ b/CommandDotNet/Help/BasicHelpTextProvider.cs
@@ -74,7 +74,7 @@ namespace CommandDotNet.Help
 
                 commandsBuilder.Append("Use \"");
                 commandsBuilder.AppendUsageCommandNames(command, _appSettings);
-                commandsBuilder.AppendLine($" [command] --{Constants.HelpArgumentTemplate.Name}\" for more information about a command.");
+                commandsBuilder.AppendLine($" [command] --{Constants.HelpArgumentTemplate.LongName}\" for more information about a command.");
             }
 
             return commandsBuilder;
@@ -84,7 +84,7 @@ namespace CommandDotNet.Help
         {
             var optionsBuilder = new StringBuilder();
             var options = command.GetOptions()
-                .Where(o => _appSettings.Help.PrintHelpOption || o.Name != Constants.HelpArgumentTemplate.Name)
+                .Where(o => _appSettings.Help.PrintHelpOption || o.LongName != Constants.HelpArgumentTemplate.LongName)
                 .OrderBy(o => o.IsSystemOption)
                 .ToList();
             if (options.Any())

--- a/CommandDotNet/Help/DetailedHelpTextProvider.cs
+++ b/CommandDotNet/Help/DetailedHelpTextProvider.cs
@@ -92,7 +92,7 @@ namespace CommandDotNet.Help
 
                 commandsBuilder.Append("Use \"");
                 commandsBuilder.AppendUsageCommandNames(command, _appSettings);
-                commandsBuilder.AppendLine($" [command] --{Constants.HelpArgumentTemplate.Name}\" for more information about a command.");
+                commandsBuilder.AppendLine($" [command] --{Constants.HelpArgumentTemplate.LongName}\" for more information about a command.");
             }
 
             return commandsBuilder;
@@ -102,7 +102,7 @@ namespace CommandDotNet.Help
         {
             var optionsBuilder = new StringBuilder();
             List<Option> options = command.GetOptions()
-                .Where(o => _appSettings.Help.PrintHelpOption || o.Name != Constants.HelpArgumentTemplate.Name)
+                .Where(o => _appSettings.Help.PrintHelpOption || o.LongName != Constants.HelpArgumentTemplate.LongName)
                 .OrderBy(o => o.IsSystemOption)
                 .ToList();
             if (options.Any())

--- a/CommandDotNet/Help/HelpMiddleware.cs
+++ b/CommandDotNet/Help/HelpMiddleware.cs
@@ -35,7 +35,7 @@ namespace CommandDotNet.Help
 
         private static Task<int> DisplayHelpIfSpecified(CommandContext commandContext, Func<CommandContext, Task<int>> next)
         {
-            if (commandContext.ParseResult.ArgumentValues.Contains(Constants.HelpArgumentTemplate.Name))
+            if (commandContext.ParseResult.ArgumentValues.Contains(Constants.HelpArgumentTemplate.LongName))
             {
                 Print(commandContext.AppSettings, commandContext.ParseResult.TargetCommand);
                 return Task.FromResult(0);

--- a/CommandDotNet/Operand.cs
+++ b/CommandDotNet/Operand.cs
@@ -35,7 +35,7 @@ namespace CommandDotNet
 
         public override string ToString()
         {
-            return $"Operand: {new ArgumentTemplate(name:Name, typeDisplayName:TypeInfo.DisplayName)}";
+            return $"Operand: {new ArgumentTemplate(longName:Name, typeDisplayName:TypeInfo.DisplayName)}";
         }
 
         private bool Equals(Operand other)

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -20,18 +20,19 @@ namespace CommandDotNet
             CustomAttributes = customAttributeProvider ?? NullCustomAttributeProvider.Instance;
 
             var argumentTemplate = new ArgumentTemplate(template);
-            Name = argumentTemplate.Name;
+            LongName = argumentTemplate.LongName;
             ShortName = argumentTemplate.ShortName;
+
             TypeInfo = new TypeInfo {DisplayName = argumentTemplate.TypeDisplayName};
 
             _aliases = aliases == null
                 ? new HashSet<string>()
                 : new HashSet<string>(aliases);
-            if (!Name.IsNullOrWhitespace()) _aliases.Add(Name);
+            if (!LongName.IsNullOrWhitespace()) _aliases.Add(LongName);
             if (!ShortName.IsNullOrWhitespace()) _aliases.Add(ShortName);
         }
 
-        public string Name { get; }
+        public string Name => LongName ?? ShortName;
         public string Description { get; set; }
         
         public ITypeInfo TypeInfo { get; set; }
@@ -42,6 +43,7 @@ namespace CommandDotNet
 
         public string Template { get; }
         public string ShortName { get; }
+        public string LongName { get; }
 
         public bool Inherited { get; set; }
 
@@ -56,12 +58,12 @@ namespace CommandDotNet
 
         public override string ToString()
         {
-            return $"Option: {new ArgumentTemplate(Name, ShortName, TypeInfo.DisplayName)}";
+            return $"Option: {new ArgumentTemplate(LongName, ShortName, TypeInfo.DisplayName)}";
         }
 
         private bool Equals(Option other)
         {
-            return string.Equals(Name, other.Name) 
+            return string.Equals(LongName, other.LongName) 
                    && string.Equals(ShortName, other.ShortName);
         }
 
@@ -89,7 +91,7 @@ namespace CommandDotNet
         {
             unchecked
             {
-                var hashCode = (Name != null ? Name.GetHashCode() : 0);
+                var hashCode = (LongName != null ? LongName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (ShortName != null ? ShortName.GetHashCode() : 0);
                 return hashCode;
             }

--- a/CommandDotNet/OptionAttribute.cs
+++ b/CommandDotNet/OptionAttribute.cs
@@ -7,14 +7,9 @@ namespace CommandDotNet
     {        
         public string ShortName { get; set; }
         
-        [Obsolete("Use Name instead")]
-        public string LongName
-        {
-            get => Name; 
-            set => Name = value;
-        }
+        public string LongName { get; set; }
 
-        public string Name { get; set; }
+        string INameAndDescription.Name => LongName ?? ShortName;
 
         public BooleanMode BooleanMode { get; set; }
         


### PR DESCRIPTION
since either long or short name can be null but at least
one has to be populated, this let's .Name be Long if
populated else Short.  Name will always have a value for
any argument.  This is useful for error reporting, logging
and help