### PR TITLE
feature: alert when newer releases of app exist on github

### DIFF
--- a/CommandDotNet.Example/CommandDotNet.Example.csproj
+++ b/CommandDotNet.Example/CommandDotNet.Example.csproj
@@ -5,9 +5,10 @@
     <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CommandDotNet.GitHubReleases\CommandDotNet.NewerReleasesAlerts.csproj" />
     <ProjectReference Include="..\CommandDotNet\CommandDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 </Project>

--- a/CommandDotNet.Example/Program.cs
+++ b/CommandDotNet.Example/Program.cs
@@ -2,6 +2,7 @@
 using CommandDotNet.Example.DocExamples;
 using CommandDotNet.Example.Issues;
 using CommandDotNet.Help;
+using CommandDotNet.NewerReleasesAlerts;
 
 namespace CommandDotNet.Example
 {
@@ -25,6 +26,7 @@ namespace CommandDotNet.Example
                     TextStyle = HelpTextStyle.Detailed
                 }
             };
+
             config?.Invoke(appSettings);
             return new AppRunner<TApp>(appSettings)
                 .UseDebugDirective()
@@ -33,6 +35,7 @@ namespace CommandDotNet.Example
                 .UseFluentValidation()
                 .UsePromptForMissingOperands()
                 .UseResponseFiles()
+                .UseNewerReleaseAlertOnGitHub("bilal-fazlani", "commanddotnet")
                 .Run(args);
         }
 

--- a/CommandDotNet.GitHubReleases/AlertOnNewerReleaseMiddleware.cs
+++ b/CommandDotNet.GitHubReleases/AlertOnNewerReleaseMiddleware.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CommandDotNet.Builders;
+using CommandDotNet.Execution;
+using Semver;
+
+namespace CommandDotNet.NewerReleasesAlerts
+{
+    public static class AlertOnNewerReleaseMiddleware
+    {
+        public delegate string ParseSemanticVersionFromResponseBodyDelegate(string responseBody);
+        public delegate string PostfixAlertMessageDelegate(string latestReleaseVersion);
+
+        public delegate Task<string> OverrideHttpRequestCallback(HttpClient client, Uri requestUri);
+        
+        /// <summary>
+        /// This middleware will call the <see cref="latestReleaseUrl"/> and
+        /// use <see cref="parseSemanticVersionFromResponseBodyCallback"/> to parse a
+        /// semantic version from the response.<br/>
+        /// If the version is greater than the file version of the assembly,
+        /// an alert is output to the console.<br/>
+        /// See <see cref="GitHubMiddleware"/> for an example of how to use this method.
+        /// </summary>
+        /// <param name="appRunner">the <see cref="AppRunner"/> to run the middleware</param>
+        /// <param name="latestReleaseUrl">the url for metadata about the latest release</param>
+        /// <param name="parseSemanticVersionFromResponseBodyCallback">callback to get the semantic version for response from the <see cref="latestReleaseUrl"/></param>
+        /// <param name="postfixAlertMessageCallback">the results of this callback will be post-fixed to the alert message.  i.e. download link.</param>
+        /// <param name="overrideHttpRequestCallback">use this callback to append headers and auth info for tests. Also useful for mocking requests for unit tests.</param>
+        public static AppRunner UseNewerReleaseAlert(this AppRunner appRunner, 
+            string latestReleaseUrl,
+            ParseSemanticVersionFromResponseBodyDelegate parseSemanticVersionFromResponseBodyCallback,
+            PostfixAlertMessageDelegate postfixAlertMessageCallback = null,
+            OverrideHttpRequestCallback overrideHttpRequestCallback = null)
+        {
+            return appRunner.Configure(c =>
+            {
+                c.Services.Add(new NewerReleaseConfig
+                {
+                    LatestReleaseUrl = latestReleaseUrl,
+                    ParseSematicVersionFromResponseBodyCallback = parseSemanticVersionFromResponseBodyCallback,
+                    PostfixAlertMessageCallback = postfixAlertMessageCallback,
+                    OverrideHttpRequestCallback = overrideHttpRequestCallback
+                });
+                c.UseMiddleware(AlertOnNewVersion, MiddlewareStages.PreTransformTokens);
+            });
+        }
+
+        private class NewerReleaseConfig
+        {
+            public string LatestReleaseUrl;
+            public ParseSemanticVersionFromResponseBodyDelegate ParseSematicVersionFromResponseBodyCallback;
+            public PostfixAlertMessageDelegate PostfixAlertMessageCallback;
+            public OverrideHttpRequestCallback OverrideHttpRequestCallback { get; set; }
+        }
+
+        private static Task<int> AlertOnNewVersion(CommandContext context, Func<CommandContext, Task<int>> next)
+        {
+            NewerReleaseConfig config = context.AppConfig.Services.Get<NewerReleaseConfig>();
+
+            SemVersion latestReleaseVersion = null;
+
+            var shouldAlert = TryGetCurrentVersion(context, out var currentVersion)
+                              && TryGetLatestReleaseVersion(context, config, out latestReleaseVersion)
+                              && currentVersion < latestReleaseVersion;
+            if (shouldAlert)
+            {
+                var message = $"A newer release exists. Current:{currentVersion} Latest:{latestReleaseVersion}";
+                if (config.PostfixAlertMessageCallback != null)
+                {
+                    message += $" {config.PostfixAlertMessageCallback?.Invoke(latestReleaseVersion.ToString())}";
+                }
+                context.Console.Out.WriteLine(message);
+                context.Console.Out.WriteLine();
+            }
+
+            return next(context);
+        }
+
+        private static bool TryGetCurrentVersion(CommandContext context, out SemVersion semVersion)
+        {
+            var versionInfo = VersionInfo.GetVersionInfo(context);
+            return SemVersion.TryParse(versionInfo.Version, out semVersion);
+
+        }
+
+        private static bool TryGetLatestReleaseVersion(CommandContext context, NewerReleaseConfig config, out SemVersion semVersion)
+        {
+            try
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    httpClient.DefaultRequestHeaders.Add("User-Agent", "Other");
+
+                    var requestUri = new Uri(config.LatestReleaseUrl);
+
+                    var response = config.OverrideHttpRequestCallback?.Invoke(httpClient, requestUri).Result
+                                   ?? httpClient.GetStringAsync(requestUri).Result;
+
+                    var version = config.ParseSematicVersionFromResponseBodyCallback(response);
+
+                    return SemVersion.TryParse(version, out semVersion);
+                }
+            }
+            catch(Exception e)
+            {
+                // don't fail operation just for this
+                context.Console.Error.WriteLine($"failed to retrieve latest release info. {e.Message}");
+                semVersion = null;
+                return false;
+            }
+        }
+    }
+}

--- a/CommandDotNet.GitHubReleases/CommandDotNet.NewerReleasesAlerts.csproj
+++ b/CommandDotNet.GitHubReleases/CommandDotNet.NewerReleasesAlerts.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Drew Burlingame</Authors>
+    <Company>Drew Burlingame</Company>
+    <Description>Print alerts if current version is on the latest version</Description>
+    <PackageTags>dotnet core; console; argument parse;</PackageTags>
+    <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/bilal-fazlani/CommandDotNet</PackageProjectUrl>
+    <NeutralLanguage>English (United States)</NeutralLanguage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Semver" Version="2.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CommandDotNet\CommandDotNet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CommandDotNet.GitHubReleases/GitHubMiddleware.cs
+++ b/CommandDotNet.GitHubReleases/GitHubMiddleware.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace CommandDotNet.NewerReleasesAlerts
+{
+    public static class GitHubMiddleware
+    {
+        /// <summary>
+        /// This middleware will check if a newer release is available in GitHub releases
+        /// and output an alert with a download link if a new release exists.
+        /// </summary>
+        /// <param name="appRunner">the <see cref="AppRunner"/> to run the middleware</param>
+        /// <param name="organizationName">The name of the organization in GitHub</param>
+        /// <param name="repositoryName">The name of the repository in GitHub</param>
+        /// <param name="getVersionFromReleaseName">Provide this in cases where the release name does not follow a standard 'v1.0.0-prefix' naming convention.</param>
+        /// <param name="overrideHttpRequestCallback">use this callback to append headers and auth info for tests. Also useful for mocking requests for unit tests.</param>
+        public static AppRunner UseNewerReleaseAlertOnGitHub(this AppRunner appRunner,
+            string organizationName, string repositoryName,
+            Func<string, string> getVersionFromReleaseName = null,
+            AlertOnNewerReleaseMiddleware.OverrideHttpRequestCallback overrideHttpRequestCallback = null)
+        {
+            if (getVersionFromReleaseName == null)
+            {
+                getVersionFromReleaseName = name => name;
+            }
+
+            return appRunner.UseNewerReleaseAlert(
+                BuildLatestReleaseUrl(organizationName, repositoryName), 
+                response => getVersionFromReleaseName(GetNameFromReleaseBody(response)),
+                version => $"Download from {BuildDownloadUrl(organizationName, repositoryName, version)}",
+                overrideHttpRequestCallback);
+        }
+
+        private static string GetNameFromReleaseBody(string response)
+        {
+            JObject o = JObject.Parse(response);
+            var ver = o.SelectToken("$.name").Value<string>();
+            return ver.Replace("v", "");
+        }
+        
+        private static string BuildLatestReleaseUrl(string organizationName, string repoName) => $"https://api.github.com/repos/{organizationName}/{repoName}/releases/latest";
+        private static string BuildDownloadUrl(string organizationName, string repoName, string version) => $"https://github.com/{organizationName}/{repoName}/releases/tag/{version}";
+    }
+}

--- a/CommandDotNet.Tests/CommandDotNet.Tests.csproj
+++ b/CommandDotNet.Tests/CommandDotNet.Tests.csproj
@@ -12,11 +12,12 @@
     <PackageReference Include="FluentValidation" Version="7.6.103" />
     <PackageReference Include="JsonDiffPatch.Net" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CommandDotNet.GitHubReleases\CommandDotNet.NewerReleasesAlerts.csproj" />
     <ProjectReference Include="..\CommandDotNet.TestTools\CommandDotNet.TestTools.csproj" />
     <ProjectReference Include="..\CommandDotNet\CommandDotNet.csproj" />
   </ItemGroup>

--- a/CommandDotNet.Tests/FeatureTests/NewReleaseAlerts/NewReleaseAlertOnGitHubTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/NewReleaseAlerts/NewReleaseAlertOnGitHubTests.cs
@@ -1,0 +1,82 @@
+﻿using System.Threading.Tasks;
+using CommandDotNet.Builders;
+using CommandDotNet.NewerReleasesAlerts;
+using CommandDotNet.TestTools;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.NewReleaseAlerts
+{
+    public class NewReleaseAlertOnGitHubTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public NewReleaseAlertOnGitHubTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void ShouldAlertWhenNewerVersionExists()
+        {
+            var organizationName = "bilal-fazlani";
+            var repositoryName = "commanddotnet";
+            var version = "1.0.0";
+
+            new AppRunner<App>()
+                .Configure(c => c.Services.Set(new VersionInfo("blah", version)))
+                .UseNewerReleaseAlertOnGitHub(organizationName, repositoryName,
+                    overrideHttpRequestCallback: (client, uri) => Task.FromResult(BuildGitHubApiResponse("1.0.1")))
+                .VerifyScenario(_testOutputHelper, new Scenario
+                {
+                    WhenArgs = "Do",
+                    Then =
+                    {
+                        ResultsContainsTexts =
+                        {
+                            $"A newer release exists. Current:{version} Latest:",
+                            $"Download from https://github.com/{organizationName}/{repositoryName}/releases/tag/"
+                        }
+                    }
+                });
+        }
+
+        [Fact]
+        public void ShouldNotAlertWhenNewerVersionDoesNotExist()
+        {
+            var organizationName = "bilal-fazlani";
+            var repositoryName = "commanddotnet";
+            var version = "1.0.1";
+
+            new AppRunner<App>()
+                .Configure(c => c.Services.Set(new VersionInfo("blah", version)))
+                .UseNewerReleaseAlertOnGitHub(organizationName, repositoryName, 
+                    overrideHttpRequestCallback: (client, uri) => Task.FromResult(BuildGitHubApiResponse("1.0.0")))
+                .VerifyScenario(_testOutputHelper, new Scenario
+                {
+                    WhenArgs = "Do",
+                    Then =
+                    {
+                        ResultsNotContainsTexts =
+                        {
+                            $"A newer release exists. Current:{version} Latest:",
+                            $"Download from https://github.com/{organizationName}/{repositoryName}/releases/tag/"
+                        }
+                    }
+                });
+        }
+
+        public class App
+        {
+            public TestOutputs TestOutputs { get; set; }
+
+            public void Do()
+            {
+            }
+        }
+
+        public static string BuildGitHubApiResponse(string version) =>
+            $"{{\"url\":\"https://api.github.com/repos/bilal-fazlani/commanddotnet/releases/14394703\",\"assets_url\":\"https://api.github.com/repos/bilal-fazlani/commanddotnet/releases/14394703/assets\",\"upload_url\":\"https://uploads.github.com/repos/bilal-fazlani/commanddotnet/releases/14394703/assets{{?name,label}}\",\"html_url\":\"https://github.com/bilal-fazlani/commanddotnet/releases/tag/{version}\",\"id\":14394703,\"node_id\":\"MDc6UmVsZWFzZTE0Mzk0NzAz\",\"tag_name\":\"{version}\",\"target_commitish\":\"1091720bc6dc301ad6da8e4041c7102567064ff8\",\"name\":\"{version}\",\"draft\":false,\"author\":{{\"login\":\"bilal-fazlani\",\"id\":3396271,\"node_id\":\"MDQ6VXNlcjMzOTYyNzE=\",\"avatar_url\":\"https://avatars0.githubusercontent.com/u/3396271?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/bilal-fazlani\",\"html_url\":\"https://github.com/bilal-fazlani\",\"followers_url\":\"https://api.github.com/users/bilal-fazlani/followers\",\"following_url\":\"https://api.github.com/users/bilal-fazlani/following{{/other_user}}\",\"gists_url\":\"https://api.github.com/users/bilal-fazlani/gists{{/gist_id}}\",\"starred_url\":\"https://api.github.com/users/bilal-fazlani/starred{{/owner}}{{/repo}}\",\"subscriptions_url\":\"https://api.github.com/users/bilal-fazlani/subscriptions\",\"organizations_url\":\"https://api.github.com/users/bilal-fazlani/orgs\",\"repos_url\":\"https://api.github.com/users/bilal-fazlani/repos\",\"events_url\":\"https://api.github.com/users/bilal-fazlani/events{{/privacy}}\",\"received_events_url\":\"https://api.github.com/users/bilal-fazlani/received_events\",\"type\":\"User\",\"site_admin\":false}},\"prerelease\":false,\"created_at\":\"2018-12-06T19:38:32Z\",\"published_at\":\"2018-12-06T19:41:16Z\",\"assets\":[{{\"url\":\"https://api.github.com/repos/bilal-fazlani/commanddotnet/releases/assets/10034919\",\"id\":10034919,\"node_id\":\"MDEyOlJlbGVhc2VBc3NldDEwMDM0OTE5\",\"name\":\"CommandDotNet.{version}.nupkg\",\"label\":\"\",\"uploader\":{{\"login\":\"bilal-fazlani\",\"id\":3396271,\"node_id\":\"MDQ6VXNlcjMzOTYyNzE=\",\"avatar_url\":\"https://avatars0.githubusercontent.com/u/3396271?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/bilal-fazlani\",\"html_url\":\"https://github.com/bilal-fazlani\",\"followers_url\":\"https://api.github.com/users/bilal-fazlani/followers\",\"following_url\":\"https://api.github.com/users/bilal-fazlani/following{{/other_user}}\",\"gists_url\":\"https://api.github.com/users/bilal-fazlani/gists{{/gist_id}}\",\"starred_url\":\"https://api.github.com/users/bilal-fazlani/starred{{/owner}}{{/repo}}\",\"subscriptions_url\":\"https://api.github.com/users/bilal-fazlani/subscriptions\",\"organizations_url\":\"https://api.github.com/users/bilal-fazlani/orgs\",\"repos_url\":\"https://api.github.com/users/bilal-fazlani/repos\",\"events_url\":\"https://api.github.com/users/bilal-fazlani/events{{/privacy}}\",\"received_events_url\":\"https://api.github.com/users/bilal-fazlani/received_events\",\"type\":\"User\",\"site_admin\":false}},\"content_type\":\"application/octet-stream\",\"state\":\"uploaded\",\"size\":31856,\"download_count\":0,\"created_at\":\"2018-12-06T19:41:15Z\",\"updated_at\":\"2018-12-06T19:41:15Z\",\"browser_download_url\":\"https://github.com/bilal-fazlani/commanddotnet/releases/download/{version}/CommandDotNet.{version}.nupkg\"}},{{\"url\":\"https://api.github.com/repos/bilal-fazlani/commanddotnet/releases/assets/10034920\",\"id\":10034920,\"node_id\":\"MDEyOlJlbGVhc2VBc3NldDEwMDM0OTIw\",\"name\":\"CommandDotNet.{version}.symbols.nupkg\",\"label\":\"\",\"uploader\":{{\"login\":\"bilal-fazlani\",\"id\":3396271,\"node_id\":\"MDQ6VXNlcjMzOTYyNzE=\",\"avatar_url\":\"https://avatars0.githubusercontent.com/u/3396271?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/bilal-fazlani\",\"html_url\":\"https://github.com/bilal-fazlani\",\"followers_url\":\"https://api.github.com/users/bilal-fazlani/followers\",\"following_url\":\"https://api.github.com/users/bilal-fazlani/following{{/other_user}}\",\"gists_url\":\"https://api.github.com/users/bilal-fazlani/gists{{/gist_id}}\",\"starred_url\":\"https://api.github.com/users/bilal-fazlani/starred{{/owner}}{{/repo}}\",\"subscriptions_url\":\"https://api.github.com/users/bilal-fazlani/subscriptions\",\"organizations_url\":\"https://api.github.com/users/bilal-fazlani/orgs\",\"repos_url\":\"https://api.github.com/users/bilal-fazlani/repos\",\"events_url\":\"https://api.github.com/users/bilal-fazlani/events{{/privacy}}\",\"received_events_url\":\"https://api.github.com/users/bilal-fazlani/received_events\",\"type\":\"User\",\"site_admin\":false}},\"content_type\":\"application/octet-stream\",\"state\":\"uploaded\",\"size\":83491,\"download_count\":0,\"created_at\":\"2018-12-06T19:41:16Z\",\"updated_at\":\"2018-12-06T19:41:16Z\",\"browser_download_url\":\"https://github.com/bilal-fazlani/commanddotnet/releases/download/{version}/CommandDotNet.{version}.symbols.nupkg\"}}],\"tarball_url\":\"https://api.github.com/repos/bilal-fazlani/commanddotnet/tarball/{version}\",\"zipball_url\":\"https://api.github.com/repos/bilal-fazlani/commanddotnet/zipball/{version}\",\"body\":\"\"}}";
+    }
+}

--- a/CommandDotNet.sln
+++ b/CommandDotNet.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{6296
 		deploy.sh = deploy.sh
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandDotNet.NewerReleasesAlerts", "CommandDotNet.GitHubReleases\CommandDotNet.NewerReleasesAlerts.csproj", "{BB3E8869-107B-4E92-B6A2-2AB3A3CA2D3C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandDotNet.TestTools", "CommandDotNet.TestTools\CommandDotNet.TestTools.csproj", "{75706FAE-BFF4-42FC-A5A6-C49744C7967C}"
 EndProject
 Global
@@ -47,6 +49,10 @@ Global
 		{75706FAE-BFF4-42FC-A5A6-C49744C7967C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75706FAE-BFF4-42FC-A5A6-C49744C7967C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75706FAE-BFF4-42FC-A5A6-C49744C7967C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB3E8869-107B-4E92-B6A2-2AB3A3CA2D3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB3E8869-107B-4E92-B6A2-2AB3A3CA2D3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB3E8869-107B-4E92-B6A2-2AB3A3CA2D3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB3E8869-107B-4E92-B6A2-2AB3A3CA2D3C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CommandDotNet/AppConfigBuilder.cs
+++ b/CommandDotNet/AppConfigBuilder.cs
@@ -90,7 +90,7 @@ namespace CommandDotNet
             return this;
         }
 
-        public AppConfig Build(AppSettings appSettings)
+        internal AppConfig Build(AppSettings appSettings)
         {
             var helpProvider = _customHelpProvider ?? HelpTextProviderFactory.Create(appSettings);
 

--- a/CommandDotNet/Builders/VersionInfo.cs
+++ b/CommandDotNet/Builders/VersionInfo.cs
@@ -1,0 +1,51 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using CommandDotNet.Execution;
+
+namespace CommandDotNet.Builders
+{
+    /// <summary>
+    /// The version information for the <see cref="Assembly.GetEntryAssembly"/><br/>
+    /// For unit tests, use `AppRunner.Configure(c =&gt; c.Services.Set(new VersionInfo(...)))`
+    /// to set to specific version
+    /// </summary>
+    public class VersionInfo
+    {
+        public string Filename { get; }
+        public string Version { get; }
+
+        public VersionInfo(string filename, string version)
+        {
+            Filename = filename;
+            Version = version;
+        }
+
+        public static VersionInfo GetVersionInfo(CommandContext commandContext)
+        {
+            var appConfigServices = commandContext.AppConfig.Services;
+
+            var versionInfo = appConfigServices.Get<VersionInfo>();
+            if (versionInfo != null)
+            {
+                return versionInfo;
+            }
+
+            var hostAssembly = Assembly.GetEntryAssembly();
+            if (hostAssembly == null)
+            {
+                throw new AppRunnerException(
+                    "Unable to determine version because Assembly.GetEntryAssembly() is null. " +
+                    "This is a known issue when running unit tests in .net framework. https://tinyurl.com/y6rnjqsg" +
+                    "Set the version info in AppRunner.Configure(c => c.Services.Set(new VersionInfo(...))) " +
+                    "to create a specific version for tests");
+            }
+
+            var filename = Path.GetFileName(hostAssembly.Location);
+            var fvi = FileVersionInfo.GetVersionInfo(hostAssembly.Location);
+            versionInfo = new VersionInfo(filename, fvi.ProductVersion);
+            appConfigServices.Set(versionInfo);
+            return versionInfo;
+        }
+    }
+}

--- a/CommandDotNet/Builders/VersionMiddleware.cs
+++ b/CommandDotNet/Builders/VersionMiddleware.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using CommandDotNet.Execution;
 using CommandDotNet.Rendering;
@@ -12,7 +9,7 @@ namespace CommandDotNet.Builders
     {
         private const string VersionOptionName = "version";
         private const string VersionTemplate = "-v | --" + VersionOptionName;
-        
+
         internal static AppRunner UseVersionMiddleware(AppRunner appRunner)
         {
             return appRunner.Configure(c =>
@@ -45,34 +42,24 @@ namespace CommandDotNet.Builders
             args.CommandBuilder.AddArgument(option);
         }
 
-        private static Task<int> DisplayVersionIfSpecified(CommandContext commandContext, Func<CommandContext, Task<int>> next)
+        private static Task<int> DisplayVersionIfSpecified(CommandContext commandContext,
+            Func<CommandContext, Task<int>> next)
         {
             if (commandContext.ParseResult.ArgumentValues.Contains(VersionOptionName))
             {
-                Print(commandContext.AppConfig.AppSettings, commandContext.Console);
+                Print(commandContext, commandContext.Console);
                 return Task.FromResult(0);
             }
 
             return next(commandContext);
         }
 
-        private static void Print(AppSettings appSettings, IConsole console)
+        private static void Print(CommandContext commandContext, IConsole console)
         {
-            var hostAssembly = Assembly.GetEntryAssembly();
-            if (hostAssembly == null)
-            {
-                throw new AppRunnerException(
-                    "Unable to determine version because Assembly.GetEntryAssembly() is null. " +
-                    "This is a known issue when running unit tests in .net framework. " +
-                    "Consider disabling for test runs. " +
-                    "https://tinyurl.com/y6rnjqsg");
-            }
+            var versionInfo = VersionInfo.GetVersionInfo(commandContext);
 
-            var filename = Path.GetFileName(hostAssembly.Location);
-            console.Out.WriteLine(filename);
-
-            var fvi = FileVersionInfo.GetVersionInfo(hostAssembly.Location);
-            console.Out.WriteLine(fvi.ProductVersion);
+            console.Out.WriteLine(versionInfo.Filename);
+            console.Out.WriteLine(versionInfo.Version);
         }
     }
 }

--- a/CommandDotNet/Directives/DebugDirective.cs
+++ b/CommandDotNet/Directives/DebugDirective.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using CommandDotNet.Execution;
 
@@ -26,17 +25,9 @@ namespace CommandDotNet.Directives
         {
             if (commandContext.Tokens.TryGetDirective("debug", out _))
             {
-                var waitForDebuggerToAttach = commandContext.AppConfig.Services.Get<DebugDirectiveContext>().WaitForDebuggerToAttach;
-                var process = Process.GetCurrentProcess();
-
-                var processId = process.Id;
-
-                commandContext.Console.Out.WriteLine($"Attach your debugger to process {processId} ({process.ProcessName}).");
-
-                while (waitForDebuggerToAttach && !Debugger.IsAttached)
-                {
-                    Task.Delay(500);
-                }
+                Debugger.Attach(
+                    commandContext.Console,
+                    commandContext.AppConfig.Services.Get<DebugDirectiveContext>().WaitForDebuggerToAttach);
             }
 
             return next(commandContext);

--- a/CommandDotNet/Directives/Debugger.cs
+++ b/CommandDotNet/Directives/Debugger.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using CommandDotNet.Rendering;
+
+namespace CommandDotNet.Directives
+{
+    public static class Debugger
+    {
+        public static void Attach(IConsole console, bool waitForDebuggerToAttach)
+        {
+            var process = Process.GetCurrentProcess();
+            console.Out.WriteLine($"Attach your debugger to process {process.Id} ({process.ProcessName}).");
+
+            while (waitForDebuggerToAttach && !System.Diagnostics.Debugger.IsAttached)
+            {
+                Task.Delay(500);
+            }
+        }
+    }
+}


### PR DESCRIPTION
@bilal-fazlani  Another example of adding middleware.  I made this a separate project because of the external dependencies.  When #154 is resolved, we can make this available as another nuget package.