### PR TITLE
add well-known cancellation token

### DIFF
--- a/CommandDotNet/AppConfigBuilder.cs
+++ b/CommandDotNet/AppConfigBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using CommandDotNet.Builders;
 using CommandDotNet.Execution;
 using CommandDotNet.Extensions;
@@ -24,11 +25,12 @@ namespace CommandDotNet
         private IHelpProvider _customHelpProvider;
 
         internal IConsole Console { get; private set; } = new SystemConsole();
+        public CancellationToken CancellationToken { get; } = new CancellationToken();
 
         public BuildEvents BuildEvents { get; } = new BuildEvents();
         public TokenizationEvents TokenizationEvents { get; } = new TokenizationEvents();
         public Services Services { get; } = new Services();
-        
+
         /// <summary>Replace the internal system console with provided console</summary>
         public AppConfigBuilder UseConsole(IConsole console)
         {
@@ -94,7 +96,7 @@ namespace CommandDotNet
         {
             var helpProvider = _customHelpProvider ?? HelpTextProviderFactory.Create(appSettings);
 
-            return new AppConfig(appSettings, Console, _dependencyResolver, helpProvider, TokenizationEvents, BuildEvents, Services)
+            return new AppConfig(appSettings, Console, _dependencyResolver, helpProvider, TokenizationEvents, BuildEvents, Services, CancellationToken)
             {
                 MiddlewarePipeline = _middlewareByStage
                     .SelectMany(kvp => kvp.Value.Select(v => new {stage = kvp.Key, v.order, v.middleware}) )

--- a/CommandDotNet/Directives/DebugDirective.cs
+++ b/CommandDotNet/Directives/DebugDirective.cs
@@ -26,6 +26,7 @@ namespace CommandDotNet.Directives
             if (commandContext.Tokens.TryGetDirective("debug", out _))
             {
                 Debugger.Attach(
+                    commandContext.AppConfig.CancellationToken,
                     commandContext.Console,
                     commandContext.AppConfig.Services.Get<DebugDirectiveContext>().WaitForDebuggerToAttach);
             }

--- a/CommandDotNet/Execution/AppConfig.cs
+++ b/CommandDotNet/Execution/AppConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using CommandDotNet.Builders;
 using CommandDotNet.Help;
 using CommandDotNet.Parsing;
@@ -17,13 +18,15 @@ namespace CommandDotNet.Execution
         public TokenizationEvents TokenizationEvents { get; }
         public BuildEvents BuildEvents { get; }
         public IServices Services { get; }
+        public CancellationToken CancellationToken { get; }
 
         internal IReadOnlyCollection<ExecutionMiddleware> MiddlewarePipeline { get; set; }
         internal IReadOnlyCollection<TokenTransformation> TokenTransformations { get; set; }
 
-        public AppConfig(AppSettings appSettings, IConsole console, 
+        public AppConfig(AppSettings appSettings, IConsole console,
             IDependencyResolver dependencyResolver, IHelpProvider helpProvider,
-            TokenizationEvents tokenizationEvents, BuildEvents buildEvents, IServices services)
+            TokenizationEvents tokenizationEvents, BuildEvents buildEvents, IServices services,
+            CancellationToken cancellationToken)
         {
             AppSettings = appSettings;
             Console = console;
@@ -32,6 +35,7 @@ namespace CommandDotNet.Execution
             TokenizationEvents = tokenizationEvents;
             BuildEvents = buildEvents;
             Services = services;
+            CancellationToken = cancellationToken;
         }
     }
 }


### PR DESCRIPTION
the token can be used by the app to trigger
a cancellation of the process.

This creates a well known single token that
all middleware can reference.

A feature will be added later to enable
cancellation using this token