### PR TITLE
rehome command context

### DIFF
--- a/CommandDotNet/CommandContext.cs
+++ b/CommandDotNet/CommandContext.cs
@@ -1,8 +1,9 @@
-﻿using CommandDotNet.Parsing;
+﻿using CommandDotNet.Execution;
+using CommandDotNet.Parsing;
 using CommandDotNet.Rendering;
 using CommandDotNet.Tokens;
 
-namespace CommandDotNet.Execution
+namespace CommandDotNet
 {
     public class CommandContext
     {


### PR DESCRIPTION
It can be used for the Middleware interceptor methods and
commonly used classes should be in root namespace to
simplify use and discovery for devs