### PR TITLE
make InterceptorInvocation publicly available

### DIFF
--- a/CommandDotNet/ClassModeling/Definitions/ClassCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/ClassCommandDef.cs
@@ -27,7 +27,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 
         public IReadOnlyCollection<ICommandDef> SubCommands => _subCommands.Value;
 
-        public IMethodDef MiddlewareMethodDef { get; }
+        public IMethodDef InterceptorMethodDef { get; }
 
         public IMethodDef InvokeMethodDef => _defaultCommandDef.InvokeMethodDef;
 
@@ -49,11 +49,11 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             var (middlewareMethod, defaultCommand, localCommands) = ParseMethods(commandContext.AppConfig);
 
-            MiddlewareMethodDef = middlewareMethod;
+            InterceptorMethodDef = middlewareMethod;
             _defaultCommandDef = defaultCommand;
 
             Arguments = _defaultCommandDef.Arguments
-                .Union(MiddlewareMethodDef.ArgumentDefs)
+                .Union(InterceptorMethodDef.ArgumentDefs)
                 .ToArray();
 
             // lazy loading prevents walking the entire hierarchy of sub-commands
@@ -68,7 +68,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             foreach (var method in CommandHostClassType.GetDeclaredMethods())
             {
-                if (MethodDef.IsMiddlewareMethod(method))
+                if (MethodDef.IsInterceptorMethod(method))
                 {
                     if (middlewareMethodInfo != null)
                     {

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -29,7 +29,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             if (commandDef.IsExecutable)
             {
-                commandDef.MiddlewareMethodDef.ArgumentDefs
+                commandDef.InterceptorMethodDef.ArgumentDefs
                     .Select(d => d.Argument)
                     .OfType<Option>()
                     .Where(o => o.Inherited)

--- a/CommandDotNet/ClassModeling/Definitions/DelegateCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DelegateCommandDef.cs
@@ -16,7 +16,7 @@ namespace CommandDotNet.ClassModeling.Definitions
         public bool IsExecutable => true;
         public IReadOnlyCollection<IArgumentDef> Arguments { get; }
         public IReadOnlyCollection<ICommandDef> SubCommands { get; } = new List<ICommandDef>().AsReadOnly();
-        public IMethodDef MiddlewareMethodDef { get; }
+        public IMethodDef InterceptorMethodDef { get; }
         public IMethodDef InvokeMethodDef { get; }
         public Command Command { get; set; }
 
@@ -25,7 +25,7 @@ namespace CommandDotNet.ClassModeling.Definitions
             _delegate = handlerDelegate;
             
             Name = name;
-            MiddlewareMethodDef = NullMethodDef.Instance;
+            InterceptorMethodDef = NullMethodDef.Instance;
             InvokeMethodDef = new MethodDef(handlerDelegate.Method, appConfig);
             Arguments = InvokeMethodDef.ArgumentDefs;
 

--- a/CommandDotNet/ClassModeling/Definitions/ICommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/ICommandDef.cs
@@ -12,7 +12,7 @@ namespace CommandDotNet.ClassModeling.Definitions
         bool IsExecutable { get; }
         IReadOnlyCollection<IArgumentDef> Arguments { get; }
         IReadOnlyCollection<ICommandDef> SubCommands { get; }
-        IMethodDef MiddlewareMethodDef { get; }
+        IMethodDef InterceptorMethodDef { get; }
         IMethodDef InvokeMethodDef { get; }
         Command Command { get; set; }
     }

--- a/CommandDotNet/ClassModeling/Definitions/IMethodDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/IMethodDef.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using CommandDotNet.Execution;
 
 namespace CommandDotNet.ClassModeling.Definitions
@@ -8,6 +6,5 @@ namespace CommandDotNet.ClassModeling.Definitions
     internal interface IMethodDef : IInvocation
     {
         IReadOnlyCollection<IArgumentDef> ArgumentDefs { get; }
-        Task<int> InvokeAsMiddleware(CommandContext commandContext, object instance, Func<CommandContext, Task<int>> next);
     }
 }

--- a/CommandDotNet/ClassModeling/Definitions/MethodCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/MethodCommandDef.cs
@@ -15,17 +15,17 @@ namespace CommandDotNet.ClassModeling.Definitions
         public bool IsExecutable => true;
         public IReadOnlyCollection<IArgumentDef> Arguments { get; }
         public IReadOnlyCollection<ICommandDef> SubCommands { get; } = new List<ICommandDef>().AsReadOnly();
-        public IMethodDef MiddlewareMethodDef { get; }
+        public IMethodDef InterceptorMethodDef { get; }
         public IMethodDef InvokeMethodDef { get; }
         public Command Command { get; set; }
         
-        public MethodCommandDef(MethodInfo method, Type commandHostClassType, IMethodDef middlewareMethodDef, AppConfig appConfig)
+        public MethodCommandDef(MethodInfo method, Type commandHostClassType, IMethodDef interceptorMethodDef, AppConfig appConfig)
         {
             _method = method;
 
             Name = method.BuildName(appConfig);
             CommandHostClassType = commandHostClassType;
-            MiddlewareMethodDef = middlewareMethodDef;
+            InterceptorMethodDef = interceptorMethodDef;
             InvokeMethodDef = new MethodDef(method, appConfig);
             Arguments = InvokeMethodDef.ArgumentDefs;
         }

--- a/CommandDotNet/ClassModeling/Definitions/NullCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/NullCommandDef.cs
@@ -17,7 +17,7 @@ namespace CommandDotNet.ClassModeling.Definitions
         public bool IsExecutable => false;
         public IReadOnlyCollection<IArgumentDef> Arguments => new List<IArgumentDef>().AsReadOnly();
         public IReadOnlyCollection<ICommandDef> SubCommands => new List<ICommandDef>().AsReadOnly();
-        public IMethodDef MiddlewareMethodDef { get; } = NullMethodDef.Instance;
+        public IMethodDef InterceptorMethodDef { get; } = NullMethodDef.Instance;
         public IMethodDef InvokeMethodDef { get; } = NullMethodDef.Instance;
         public Command Command { get; set; }
     }

--- a/CommandDotNet/ClassModeling/Definitions/NullMethodDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/NullMethodDef.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
-using CommandDotNet.Execution;
 
 namespace CommandDotNet.ClassModeling.Definitions
 {
@@ -21,12 +20,7 @@ namespace CommandDotNet.ClassModeling.Definitions
         public IReadOnlyCollection<ParameterInfo> Parameters { get; } = new ParameterInfo[0];
         public object[] ParameterValues { get; } = new object[0];
 
-        public Task<int> InvokeAsMiddleware(CommandContext commandContext, object instance, Func<CommandContext, Task<int>> next)
-        {
-            return next(commandContext);
-        }
-
-        public object Invoke(CommandContext commandContext, object instance)
+        public object Invoke(CommandContext commandContext, object instance, Func<CommandContext, Task<int>> next)
         {
             throw new NotImplementedException("We should never reach this");
         }

--- a/CommandDotNet/Execution/IInvocation.cs
+++ b/CommandDotNet/Execution/IInvocation.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace CommandDotNet.Execution
 {
@@ -29,6 +31,6 @@ namespace CommandDotNet.Execution
         MethodInfo MethodInfo { get; }
 
         /// <summary>Invokes the instance</summary>
-        object Invoke(CommandContext commandContext, object instance);
+        object Invoke(CommandContext commandContext, object instance, Func<CommandContext, Task<int>> next);
     }
 }

--- a/CommandDotNet/Execution/InvocationContext.cs
+++ b/CommandDotNet/Execution/InvocationContext.cs
@@ -3,6 +3,7 @@
     public class InvocationContext
     {
         public object Instance { get; set; }
+        public IInvocation InterceptorInvocation { get; set; }
         public IInvocation CommandInvocation { get; set; }
     }
 }

--- a/CommandDotNet/Extensions/EnumerableExtensions.cs
+++ b/CommandDotNet/Extensions/EnumerableExtensions.cs
@@ -7,6 +7,8 @@ namespace CommandDotNet.Extensions
 {
     internal static class EnumerableExtensions
     {
+        internal static bool IsNullOrEmpty<T>(this IEnumerable<T> items) => items == null || !items.Any();
+
         internal static IEnumerable<T> ToEnumerable<T>(this T instance)
         {
             yield return instance;

--- a/CommandDotNet/Extensions/TypeExtensions.cs
+++ b/CommandDotNet/Extensions/TypeExtensions.cs
@@ -7,6 +7,13 @@ using System.Runtime.CompilerServices;
 
 namespace CommandDotNet.Extensions
 {
+    internal static class MemberInfoExtensions
+    {
+        internal static string FullName(this MemberInfo memberInfo, bool includeNamespace = false) =>
+            includeNamespace
+                ? $"{memberInfo.DeclaringType?.FullName}.{memberInfo.Name}"
+                : $"{memberInfo.DeclaringType?.Name}.{memberInfo.Name}";
+    }
     internal static class TypeExtensions
     {
         internal static IEnumerable<MethodInfo> GetDeclaredMethods(this Type type)


### PR DESCRIPTION
Changed the name of MiddlewareMethod to Interceptor.
I think this better describes how it's thought of and
reduces confusion with other middleware.

IInvocation.Invoke added a 'next' param which
will be null for the main command but populated
for interceptors

Discovered a possible bug where if someone
reassigned the invocations on the InvocationContext
they wouldn't have been honored because
we had to get the invocation from the ICommandDef.