### PR TITLE
fixes #169, null ref creating instance of fluent validator

### DIFF
--- a/CommandDotNet/DependencyResolverExtensions.cs
+++ b/CommandDotNet/DependencyResolverExtensions.cs
@@ -15,7 +15,7 @@ namespace CommandDotNet
             try
             {
                 item = resolver.Resolve(type);
-                return true;
+                return item != null;
             }
             catch (Exception)
             {


### PR DESCRIPTION
The bug was caused by the TryResolve ext method
returning true when no instance was resolved.

#169 is already fixed in V3 because it will use
the containers TryResolve which is expected
to behave correctly.