### PR TITLE
monorepo deploy

### DIFF
--- a/CommandDotNet.GitHubReleases/CommandDotNet.NewerReleasesAlerts.csproj
+++ b/CommandDotNet.GitHubReleases/CommandDotNet.NewerReleasesAlerts.csproj
@@ -12,6 +12,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
     <NeutralLanguage>English (United States)</NeutralLanguage>
+    <Version>1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/CommandDotNet.GitHubReleases/CommandDotNet.NewerReleasesAlerts.csproj
+++ b/CommandDotNet.GitHubReleases/CommandDotNet.NewerReleasesAlerts.csproj
@@ -1,17 +1,30 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
     <Authors>Drew Burlingame</Authors>
-    <Company>Drew Burlingame</Company>
+    <NeutralLanguage>en-US</NeutralLanguage>
     <Description>Print alerts if current version is on the latest version</Description>
-    <PackageTags>dotnet core; console; argument parse;</PackageTags>
-    <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
+    <PackageTags>dotnet core; console; argument parse; test;</PackageTags>
     <PackageProjectUrl>https://github.com/bilal-fazlani/CommandDotNet</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
     <NeutralLanguage>English (United States)</NeutralLanguage>
   </PropertyGroup>
-
+  <PropertyGroup>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <!-- This is for future -->
+    <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat> -->
+    <!-- https://github.com/dotnet/sourcelink/blob/master/docs/README.md#embedallsources -->
+    <EmbedAllSources>true</EmbedAllSources>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Semver" Version="2.0.4" />

--- a/CommandDotNet.TestTools/CommandDotNet.TestTools.csproj
+++ b/CommandDotNet.TestTools/CommandDotNet.TestTools.csproj
@@ -12,6 +12,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
     <NeutralLanguage>English (United States)</NeutralLanguage>
+    <Version>1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/CommandDotNet.TestTools/CommandDotNet.TestTools.csproj
+++ b/CommandDotNet.TestTools/CommandDotNet.TestTools.csproj
@@ -1,15 +1,29 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
     <Authors>Drew Burlingame</Authors>
-    <Company>Drew Burlingame</Company>
+    <NeutralLanguage>en-US</NeutralLanguage>
     <Description>Test your CommandDotNet application</Description>
+    <PackageTags>dotnet core; console; argument parse; test;</PackageTags>
     <PackageProjectUrl>https://github.com/bilal-fazlani/CommandDotNet</PackageProjectUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
-    <PackageTags>dotnet core; console; argument parse; test;</PackageTags>
     <NeutralLanguage>English (United States)</NeutralLanguage>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <!-- This is for future -->
+    <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat> -->
+    <!-- https://github.com/dotnet/sourcelink/blob/master/docs/README.md#embedallsources -->
+    <EmbedAllSources>true</EmbedAllSources>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CommandDotNet/CommandDotNet.csproj
+++ b/CommandDotNet/CommandDotNet.csproj
@@ -9,22 +9,22 @@
     <PackageTags>dotnet core; console; argument parse;</PackageTags>
     <PackageProjectUrl>https://github.com/bilal-fazlani/CommandDotNet</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
     <!--<NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>-->
-    <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
   </PropertyGroup>
-    <PropertyGroup>
-        <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-        <IncludeSymbols>false</IncludeSymbols>
-        <!-- This is for future -->
-        <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat> -->
-        <!-- https://github.com/dotnet/sourcelink/blob/master/docs/README.md#embedallsources -->
-        <EmbedAllSources>true</EmbedAllSources>
-        <DebugType>embedded</DebugType>
-        <DebugSymbols>true</DebugSymbols>
-    </PropertyGroup>
+  <PropertyGroup>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <!-- This is for future -->
+    <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat> -->
+    <!-- https://github.com/dotnet/sourcelink/blob/master/docs/README.md#embedallsources -->
+    <EmbedAllSources>true</EmbedAllSources>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="7.6.103" />
     <PackageReference Include="Humanizer.Core" Version="2.5.16" />

--- a/CommandDotNet/CommandDotNet.csproj
+++ b/CommandDotNet/CommandDotNet.csproj
@@ -11,7 +11,8 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
-    <!--<NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>-->
+    <Version>1.0.0</Version>
+      <!--<NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>-->
   </PropertyGroup>
   <PropertyGroup>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-TRAVIS_TAG=CommandDotNet.TestTools_1.0.0
+#TRAVIS_TAG=CommandDotNet.TestTools_1.0.0
 #TRAVIS_TAG=CommandDotNet.TestTools_1.0.0-preview1
 
 parseTravisTag () {

--- a/deploy.sh
+++ b/deploy.sh
@@ -95,6 +95,8 @@ updateProjectRefsInNuspec () {
   for i in ${!PROJECT_REF_NAMES[@]}; do
     projectRefName=${PROJECT_REF_NAMES[$i]}
     projectRefVersion=${PROJECT_REF_VERSIONS[$i]}
+
+    chmod 666 $NUSPEC_FILE
     
     # dotnet pack has a bug: https://github.com/NuGet/Home/issues/7328
     # - project reference versions set to pack version 

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,14 +12,64 @@ parseTravisTag () {
   fi
 }
 
+updateProjectRefsInNuspec () {  
+  ## get list of projects in solution referenced by PROJECT_NAME
+  ## after grep, lines will look like ..\CommandDotNet\CommandDotNet.csproj
+  ## sed removes start ..\
+  dotnet list ../../$PROJECT_FILE reference | grep csproj | sed 's/^...//' | while read -r projectRefFile; do    
+    if [[ $projectRefFile =~ (.+)[/\\](.+) ]]
+    then
+      projectRefName=${BASH_REMATCH[1]}
+    else
+      >&2 echo "failed to parse projectRefFile of value '$projectRefFile'"
+      exit 1
+    fi
+
+    tagName=`git describe --tags --match "$projectRefName_*"`
+
+    if [[ $tagName =~ (.+)_(.+)-(.+)-(.+) ]]
+    then
+      projectRefVersion=${BASH_REMATCH[2]}
+      echo "projectRefVersion=$projectRefVersion"
+    else
+      >&2 echo "failed to parse projectRefVersion of value '$tagName' for $projectRefName"
+      exit 1
+    fi
+
+    echo "projectRefFile=$projectRefFile projectRefName=$projectRefName projectRefVersion=$projectRefVersion tagName=$tagName"
+    
+    # dotnet pack has a bug: https://github.com/NuGet/Home/issues/7328
+    # - project reference versions set to pack version 
+    # so we'll check DEPLOYMENT_VERSION and also 1.0.0 so this still works when the bug is fixed     
+    sed -i "s/id=\"$projectRefName\" version=\"1.0.0\"/id=\"$projectRefName\" version=\"$projectRefVersion\"/" $NUSPEC_FILE
+    sed -i "s/id=\"$projectRefName\" version=\"$DEPLOYMENT_VERSION\"/id=\"$projectRefName\" version=\"$projectRefVersion\"/" $NUSPEC_FILE
+  done
+}
+
 parseTravisTag
+
+PROJECT_FILE=$PROJECT_NAME/$PROJECT_NAME.csproj
+NUPKG_FILE=$PROJECT_NAME.$DEPLOYMENT_VERSION.nupkg
+NUSPEC_FILE=$PROJECT_NAME.nuspec
 
 # PACKAGE
 dotnet pack \
 -o output \
 -c Release \
-$PROJECT_NAME/$PROJECT_NAME.csproj \
-/p:Version=$DEPLOYMENT_VERSION
+$PROJECT_FILE \
+-p:Version=$DEPLOYMENT_VERSION \
+--no-restore \
+#-v:diag
+
+# update nuspec with correct versions of referenced projects  
+cd $PROJECT_NAME/output
+unzip $NUPKG_FILE $NUSPEC_FILE
+
+updateProjectRefsInNuspec
+
+zip $NUPKG_FILE $NUSPEC_FILE
+rm $NUSPEC_FILE
+cd ../..
 
 # PUBLISH TO NUGET
 dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET CommandDotNet/output/$PROJECT_NAME.$DEPLOYMENT_VERSION.nupkg

--- a/deploy.sh
+++ b/deploy.sh
@@ -168,4 +168,4 @@ echo " "
 fixNupkgVersions
 
 # PUBLISH TO NUGET
-#dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET CommandDotNet/output/$NUPKG_FILE
+dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET CommandDotNet/output/$NUPKG_FILE

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 
+TRAVIS_TAG=CommandDotNet.TestTools_1.0.0
+#TRAVIS_TAG=CommandDotNet.TestTools_1.0.0-preview1
+
 parseTravisTag () {
+  echo " "
+  echo ">>> parseTravisTag"
+  echo " "
+
   if [[ $TRAVIS_TAG =~ (.+)_(.+) ]]
   then
     PROJECT_NAME=${BASH_REMATCH[1]}
@@ -10,33 +17,84 @@ parseTravisTag () {
     >&2 echo "failed to parse TRAVIS_TAG of value '$TRAVIS_TAG'"
     exit 1
   fi
+  
+  echo " "
+  echo "<<< parseTravisTag"
+  echo " "
 }
 
-updateProjectRefsInNuspec () {  
+parseProjectRefs () {  
+  echo " "
+  echo ">>> parseProjectRefs"
+  echo " "
+
   ## get list of projects in solution referenced by PROJECT_NAME
   ## after grep, lines will look like ..\CommandDotNet\CommandDotNet.csproj
   ## sed removes start ..\
-  dotnet list ../../$PROJECT_FILE reference | grep csproj | sed 's/^...//' | while read -r projectRefFile; do    
+  while read -r projectRefFile; do    
     if [[ $projectRefFile =~ (.+)[/\\](.+) ]]
     then
       projectRefName=${BASH_REMATCH[1]}
+      PROJECT_REF_NAMES+=($projectRefName)
     else
       >&2 echo "failed to parse projectRefFile of value '$projectRefFile'"
       exit 1
     fi
 
-    tagName=`git describe --tags --match "$projectRefName_*"`
+    tagDescr=`git describe --tags --abbrev=0 --match "$projectRefName"_*`
 
-    if [[ $tagName =~ (.+)_(.+)-(.+)-(.+) ]]
+    if [[ $tagDescr =~ (.+)_(.+) ]]
     then
       projectRefVersion=${BASH_REMATCH[2]}
-      echo "projectRefVersion=$projectRefVersion"
+      PROJECT_REF_VERSIONS+=($projectRefVersion)
     else
-      >&2 echo "failed to parse projectRefVersion of value '$tagName' for $projectRefName"
+      >&2 echo "failed to parse projectRefVersion of value '$tagDescr' for $projectRefName"
       exit 1
     fi
+    
+    #echo "projectRefFile    = $projectRefFile"
+    #echo "projectRefName    = $projectRefName"
+    #echo "projectRefVersion = $projectRefVersion"
+    #echo "tagDescr          = $tagDescr"
+    
+  done  < <(dotnet list $PROJECT_FILE reference | grep csproj | sed 's/^...//')
+  # ^^^ use process substitution instead of piping into while statement
+  # keeps while loop in the same context so it can update the arrays
+  # https://stackoverflow.com/questions/9985076/bash-populate-an-array-in-loop
+  
+  echo " "
+  echo "<<< parseProjectRefs"
+  echo " "
+}
 
-    echo "projectRefFile=$projectRefFile projectRefName=$projectRefName projectRefVersion=$projectRefVersion tagName=$tagName"
+updateProjectRefsInSln() {
+  echo " "
+  echo " >>> updateProjectRefsInSln"
+  echo " "
+
+  for i in ${!PROJECT_REF_NAMES[@]}; do
+    projectRefName=${PROJECT_REF_NAMES[$i]}
+    projectRefVersion=${PROJECT_REF_VERSIONS[$i]}
+
+    projectFile=$projectRefName/$projectRefName.csproj
+    
+    echo "update version in project $projectRefName $projectRefVersion"
+    sed -i "s,<Version>1.0.0</Version>,<Version>$projectRefVersion</Version>," $projectFile    
+  done
+  
+  echo " "
+  echo " <<< updateProjectRefsInSln"
+  echo " "
+}
+
+updateProjectRefsInNuspec () {
+  echo " "
+  echo " >>> updateProjectRefsInNuspec"
+  echo " "
+  
+  for i in ${!PROJECT_REF_NAMES[@]}; do
+    projectRefName=${PROJECT_REF_NAMES[$i]}
+    projectRefVersion=${PROJECT_REF_VERSIONS[$i]}
     
     # dotnet pack has a bug: https://github.com/NuGet/Home/issues/7328
     # - project reference versions set to pack version 
@@ -44,6 +102,30 @@ updateProjectRefsInNuspec () {
     sed -i "s/id=\"$projectRefName\" version=\"1.0.0\"/id=\"$projectRefName\" version=\"$projectRefVersion\"/" $NUSPEC_FILE
     sed -i "s/id=\"$projectRefName\" version=\"$DEPLOYMENT_VERSION\"/id=\"$projectRefName\" version=\"$projectRefVersion\"/" $NUSPEC_FILE
   done
+  
+  echo " "
+  echo " <<< updateProjectRefsInNuspec"
+  echo " "
+}
+
+fixNupkgVersions () {
+  echo " "
+  echo " >>> fixNupkgVersions"
+  echo " "
+  
+  # update nuspec with correct versions of referenced projects  
+  cd $PROJECT_NAME/output
+  unzip $NUPKG_FILE $NUSPEC_FILE
+  
+  updateProjectRefsInNuspec
+  
+  zip $NUPKG_FILE $NUSPEC_FILE
+  rm $NUSPEC_FILE
+  cd ../..
+  
+  echo " "
+  echo " <<< fixNupkgVersions"
+  echo " "
 }
 
 parseTravisTag
@@ -52,24 +134,38 @@ PROJECT_FILE=$PROJECT_NAME/$PROJECT_NAME.csproj
 NUPKG_FILE=$PROJECT_NAME.$DEPLOYMENT_VERSION.nupkg
 NUSPEC_FILE=$PROJECT_NAME.nuspec
 
+declare -a PROJECT_REF_NAMES
+declare -a PROJECT_REF_VERSIONS
+
+echo "PROJECT_NAME         = $PROJECT_NAME"
+echo "DEPLOYMENT_VERSION   = $DEPLOYMENT_VERSION"
+echo "PROJECT_FILE         = $PROJECT_FILE"
+echo "NUPKG_FILE           = $NUPKG_FILE"
+echo "NUSPEC_FILE          = $NUSPEC_FILE"
+
+parseProjectRefs
+
+echo "PROJECT_REF_NAMES    = ${PROJECT_REF_NAMES[@]}"
+echo "PROJECT_REF_VERSIONS = ${PROJECT_REF_VERSIONS[@]}"
+
+updateProjectRefsInSln
+
+echo " "
+echo ">>> pack"
+
 # PACKAGE
 dotnet pack \
 -o output \
 -c Release \
 $PROJECT_FILE \
 -p:Version=$DEPLOYMENT_VERSION \
---no-restore \
+#--no-restore \
 #-v:diag
 
-# update nuspec with correct versions of referenced projects  
-cd $PROJECT_NAME/output
-unzip $NUPKG_FILE $NUSPEC_FILE
+echo "<<< pack"
+echo " "
 
-updateProjectRefsInNuspec
-
-zip $NUPKG_FILE $NUSPEC_FILE
-rm $NUSPEC_FILE
-cd ../..
+fixNupkgVersions
 
 # PUBLISH TO NUGET
-dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET CommandDotNet/output/$PROJECT_NAME.$DEPLOYMENT_VERSION.nupkg
+#dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET CommandDotNet/output/$NUPKG_FILE

--- a/deploy.sh
+++ b/deploy.sh
@@ -170,4 +170,4 @@ echo " "
 fixNupkgVersions
 
 # PUBLISH TO NUGET
-dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET CommandDotNet/output/$NUPKG_FILE
+dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY_COMMANDDOTNET $PROJECT_NAME/output/$NUPKG_FILE


### PR DESCRIPTION
monorepo deploy uses correct project ref versions in nuspec

> nuget cannot determine the correct project semver from the files in source because the semver is stored in git tags.
> this commit will fix version references in the nuspec file before publishing.

consistent nuget in proj files - include dbg and symbols