### PR TITLE
Command.Options does not include inherited options

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/Arguments/DefaultArgumentModeTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/DefaultArgumentModeTests.cs
@@ -29,8 +29,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                     ResultsContainsTexts =
                     {
                         @"Options:
-  --ctorDefault *a  
-  --ctorOption *a"
+  --ctorDefault
+  --ctorOption"
                     }
                 }
             });
@@ -93,8 +93,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                     ResultsContainsTexts =
                     {
                         @"Options:
-  --ctorDefault *a  
-  --ctorOption *a"
+  --ctorDefault
+  --ctorOption"
                     }
                 }
             });
@@ -157,8 +157,8 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                     ResultsContainsTexts =
                     {
                         @"Options:
-  --ctorDefault *a  
-  --ctorOption *a"
+  --ctorDefault
+  --ctorOption"
                     }
                 }
             });

--- a/CommandDotNet.Tests/FeatureTests/ClassCommands/DuplicateAliasDetectedTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ClassCommands/DuplicateAliasDetectedTests.cs
@@ -96,7 +96,7 @@ namespace CommandDotNet.Tests.FeatureTests.ClassCommands
 
         class DuplicateInheritedOptionApp
         {
-            public Task<int> Intercept(InterceptorExecutionDelegate next, [Option(Inherited = true)] string lala)
+            public Task<int> Intercept(InterceptorExecutionDelegate next, [Option(AssignToExecutableSubcommands = true)] string lala)
             {
                 return next();
             }

--- a/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionTests.cs
@@ -66,13 +66,11 @@ Arguments:
 
 Options:
 
-  --stringOpt *a      <TEXT>
+  --stringOpt      <TEXT>
 
-  --skipCmd *a
+  --skipCmd
 
-  --useReturnCode *a  <NUMBER>
-
-  *a option can be used with subcommands. `[command] [options] [subcommand]`
+  --useReturnCode  <NUMBER>
 
 Commands:
 

--- a/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionWithDefaultMethodTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionWithDefaultMethodTests.cs
@@ -74,13 +74,13 @@ Arguments:
 
 Options:
 
-  --stringOpt *a      <TEXT>
+  --stringOpt  <TEXT>
 
-  --skipCmd *a
+Options also available for subcommands:
 
-  --useReturnCode *a  <NUMBER>
+  --skipCmd
 
-  *a option can be used with subcommands. `[command] [options] [subcommand]`
+  --useReturnCode  <NUMBER>
 
 Commands:
 
@@ -100,11 +100,15 @@ Use ""dotnet testhost.dll [command] --help"" for more information about a comman
                     WhenArgs = "Do -h",
                     Then =
                     {
-                        Result = @"Usage: dotnet testhost.dll Do [arguments]
+                        Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
 
 Arguments:
 
-  arg1  <NUMBER>"
+  arg1  <NUMBER>
+
+Options:
+
+  --stringOpt  <TEXT>"
                     }
                 });
         }
@@ -227,6 +231,7 @@ Arguments:
 
             public class InterceptOptions : IArgumentModel
             {
+                [Option(AssignToExecutableSubcommands = true)]
                 public string stringOpt { get; set; }
                 public bool skipCmd { get; set; } = false;
                 public int? useReturnCode { get; set; }

--- a/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests.cs
@@ -385,7 +385,7 @@ lala (Text): fishies"
         {
             private TestOutputs TestOutputs { get; set; }
 
-            public Task<int> Intercept(InterceptorExecutionDelegate next, int intercept1, [Option(Inherited = true)] int inherited1)
+            public Task<int> Intercept(InterceptorExecutionDelegate next, int intercept1, [Option(AssignToExecutableSubcommands = true)] int inherited1)
             {
                 TestOutputs.Capture(new InterceptResult { Intercept1 = intercept1, Inherited1 = inherited1 });
                 return next();

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -38,13 +38,6 @@ namespace CommandDotNet.ClassModeling.Definitions
                 .Select(a => a.ToArgument(command, commandContext.AppConfig, true))
                 .ForEach(commandBuilder.AddArgument);
 
-            if (commandDef.IsExecutable)
-            {
-                command.GetParentCommands()
-                    .SelectMany(c => c.Options.Where(o => o.Inherited))
-                    .ForEach(commandBuilder.AddArgument);
-            }
-
             commandDef.SubCommands
                 .Select(c => c.ToCommand(command, commandContext).Command)
                 .ForEach(commandBuilder.AddSubCommand);
@@ -109,6 +102,9 @@ namespace CommandDotNet.ClassModeling.Definitions
                 var booleanMode = GetOptionBooleanMode(argumentDef, appConfig.AppSettings.BooleanMode, optionAttr);
                 var argumentArity = ArgumentArity.Default(argumentDef.Type, argumentDef.HasDefaultValue, booleanMode);
 
+                var assignOnlyToExecutableSubcommands = optionAttr?.AssignToExecutableSubcommands ?? false;
+                isInterceptorOption = isInterceptorOption && !assignOnlyToExecutableSubcommands;
+
                 var longName = optionAttr?.ShortName != null 
                     ? optionAttr?.LongName 
                     : (optionAttr?.LongName ?? argumentDef.Name);
@@ -121,10 +117,10 @@ namespace CommandDotNet.ClassModeling.Definitions
                     definitionSource: argumentDef.SourcePath,
                     customAttributes: argumentDef.CustomAttributes,
                     isInterceptorOption: isInterceptorOption,
+                    assignToExecutableSubcommands: assignOnlyToExecutableSubcommands,
                     valueProxy: argumentDef.ValueProxy)
                 {
                     Description = optionAttr?.Description,
-                    Inherited = optionAttr?.Inherited ?? false,
                     DefaultValue = defaultValue
                 };
             }

--- a/CommandDotNet/CommandExtensions.cs
+++ b/CommandDotNet/CommandExtensions.cs
@@ -11,36 +11,25 @@ namespace CommandDotNet
         /// <summary>Get the root command</summary>
         public static Command GetRootCommand(this Command command) => command.GetParentCommands(true).Last();
 
-        /// <summary>
-        /// Return all <see cref="Operand"/>s and <see cref="Option"/>s for the command.
-        /// </summary>
+        /// <summary> Return all <see cref="Operand"/>s and <see cref="Option"/>s for the command</summary>
         /// <param name="command">The command</param>
-        /// <param name="includeInterceptorOptions">
-        /// When true, includes options from interceptors of all parent commands.
-        /// Inherited options are included whether true or false.
-        /// </param>
+        /// <param name="includeInterceptorOptions">When true, includes options from interceptors of all parent commands</param>
         public static IEnumerable<IArgument> AllArguments(this Command command, bool includeInterceptorOptions = false)
         {
             return command.Operands.Cast<IArgument>()
                 .Concat(command.AllOptions(includeInterceptorOptions));
         }
 
-        /// <summary>
-        /// Return all <see cref="Option"/>s for the command. Inherited options are already included.
-        /// </summary>
+        /// <summary>Return all <see cref="Option"/>s for the command.</summary>
         /// <param name="command">The command</param>
-        /// <param name="includeInterceptorOptions">
-        /// When true, includes options from interceptors of all parent commands.
-        /// Inherited options are included whether true or false.
-        /// </param>
+        /// <param name="includeInterceptorOptions">When true, includes options from interceptors of all parent commands</param>
         public static IEnumerable<Option> AllOptions(this Command command, bool includeInterceptorOptions = false) =>
             includeInterceptorOptions
                 ? command.Options
                     .Concat(command
                         .GetParentCommands()
                         .Reverse()
-                        // inherited options are already included in allLocalArgs
-                        .SelectMany(c => c.Options.Where(o => o.IsInterceptorOption && !o.Inherited)))
+                        .SelectMany(c => c.Options.Where(o => o.IsInterceptorOption)))
                 : command.Options;
 
         /// <summary>returns the parents of the current command, sorted from closest to farthest parent</summary>

--- a/CommandDotNet/Help/BasicHelpTextProvider.cs
+++ b/CommandDotNet/Help/BasicHelpTextProvider.cs
@@ -20,7 +20,7 @@ namespace CommandDotNet.Help
         {
             string Name(IArgument arg)
             {
-                return ArgumentName(arg) + ArgumentFootNoteSymbols(command, arg);
+                return ArgumentName(arg);
             }
 
             var nameMaxLength = arguments.Max(a => Name(a)?.Length) ?? 0;

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -39,11 +39,18 @@ namespace CommandDotNet
             IEnumerable<string> aliases = null,
             ICustomAttributeProvider customAttributes = null,
             bool isInterceptorOption = false,
+            bool assignToExecutableSubcommands = false,
             ValueProxy valueProxy = null)
         {
             if (longName.IsNullOrWhitespace() && shortName.IsNullOrWhitespace())
             {
-                throw new ArgumentException("a long or short name is required");
+                throw new ArgumentException($"a long or short name is required. source:{definitionSource}");
+            }
+
+            if (isInterceptorOption && assignToExecutableSubcommands)
+            {
+                throw new ArgumentException($"{nameof(isInterceptorOption)} and {nameof(assignToExecutableSubcommands)} are mutually exclusive. " +
+                                            $"They cannot both be true. source:{definitionSource}");
             }
 
             _valueProxy = valueProxy;
@@ -53,8 +60,8 @@ namespace CommandDotNet
             Arity = arity;
             DefinitionSource = definitionSource;
             IsInterceptorOption = isInterceptorOption;
+            AssignToExecutableSubcommands = assignToExecutableSubcommands;
             CustomAttributes = customAttributes ?? NullCustomAttributeProvider.Instance;
-
             LongName = longName;
             ShortName = shortName;
 
@@ -125,8 +132,15 @@ namespace CommandDotNet
             }
         }
 
-        /// <summary>If true, this option is inherited from a command interceptor method and can be specified after the target command</summary>
-        public bool Inherited { get; set; }
+        [Obsolete("Use AssignToExecutableSubcommands instead")]
+        public bool Inherited => AssignToExecutableSubcommands;
+
+        /// <summary>
+        /// When true, this option is an Inherited option, defined by a command interceptor method
+        /// and assigned to executable subcommands of the interceptor.<br/>
+        /// Note: The Parent will still be the defining command, not the target command.
+        /// </summary>
+        public bool AssignToExecutableSubcommands { get; }
 
         /// <summary>
         /// True when option is not defined in class model

--- a/CommandDotNet/OptionAttribute.cs
+++ b/CommandDotNet/OptionAttribute.cs
@@ -4,16 +4,33 @@ namespace CommandDotNet
 {
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
     public class OptionAttribute : Attribute, INameAndDescription
-    {        
+    {
+        /// <summary>Must be a single character</summary>
         public string ShortName { get; set; }
-        
+
         public string LongName { get; set; }
 
         string INameAndDescription.Name => LongName;
 
+        /// <summary>
+        /// The <see cref="BooleanMode"/> to use for this option.
+        /// If not specified, the default from <see cref="AppSettings"/> will be used.
+        /// </summary>
         public BooleanMode BooleanMode { get; set; }
-        
-        public bool Inherited { get; set; }
+
+        [Obsolete("Use AssignToExecutableSubcommands instead")]
+        public bool Inherited
+        {
+            get => AssignToExecutableSubcommands;
+            set => AssignToExecutableSubcommands = value;
+        }
+
+        /// <summary>
+        /// When true, this option is an Inherited option, defined by a command interceptor method
+        /// and assigned to executable subcommands of the interceptor.<br/>
+        /// Note: The Parent will still be the defining command, not the target command.
+        /// </summary>
+        public bool AssignToExecutableSubcommands { get; set; }
 
         public string Description { get; set; }
     }


### PR DESCRIPTION
Inherited options should only be used for subcommands

- Move logic from mapping extensions to Command to ensure
inherited options are added to subcommands

- obsolete Inherited for AssignToExecutableSubcommands
as a more descriptive name for Option and
OptionAttribute

- update help, removing the clunky footnote concept.
since there will only be confusion when a default
command also has interceptor options, adding a new
options section is clear enough.

- leaving the term Inherited in the tests and comments
as it is more terse than AssignToExecutableSubcommands
and added Inherited term to the xml docs to make
the connection easier to see.