### PR TITLE
publish_doc.sh - use docker and support run from local dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ mono: none
 git:
   depth: false
 
+services:
+  - docker
+
 stages:
     - name: test
     - name: deploy


### PR DESCRIPTION
using a docker image to build mkdocs ensures the same
versions of python, mkdocs & material themes are used on
all machines and removes the need to install locally