### PR TITLE
Added AppOutputBase and PathMap

### DIFF
--- a/CommandDotNet/CommandDotNet.csproj
+++ b/CommandDotNet/CommandDotNet.csproj
@@ -12,6 +12,8 @@
     <PackageIconUrl>https://raw.githubusercontent.com/bilal-fazlani/CommandDotNet/master/images/nuget-icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/bilal-fazlani/CommandDotNet</RepositoryUrl>
     <Version>1.0.0</Version>
+    <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
+    <PathMap>$(AppOutputBase)=CommandDotNet/</PathMap>
       <!--<NetStandardImplicitPackageVersion>2.0.2</NetStandardImplicitPackageVersion>-->
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
With this mapping stacktraces do not show the path to the file on the file system (during compile time) that caused the exception.
Instead of e.g. /home/bilal-fazlani/.../CommandDotnet/AppRunner.cs.... the stacktrace shows CommandDotNet/AppRunner.cs
That makes it a lot prettier and less confusing for less technical users.