### PR TITLE
Expand arguments in Usage example

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/Arguments/AppsSettingsBoolModeTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/AppsSettingsBoolModeTests.cs
@@ -26,7 +26,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                 WhenArgs = "Do -h",
                 Then =
                 {
-                    Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
   operand
@@ -46,7 +46,7 @@ Options:
                 WhenArgs = "Do -h",
                 Then =
                 {
-                    Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 
@@ -70,7 +70,7 @@ Options:
                 WhenArgs = "Do -h",
                 Then =
                 {
-                    Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
   operand
@@ -90,7 +90,7 @@ Options:
                 WhenArgs = "Do -h",
                 Then =
                 {
-                    Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/Arguments/EnumerableArgTypesTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/EnumerableArgTypesTests.cs
@@ -22,7 +22,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
             {
                 Given = { AppSettings = BasicHelp },
                 WhenArgs = "EnumerableModel -h",
-                Then = { Result = @"Usage: dotnet testhost.dll EnumerableModel [arguments] [options]
+                Then = { Result = @"Usage: dotnet testhost.dll EnumerableModel [options] [arguments]
 
 Arguments:
   Args
@@ -39,7 +39,7 @@ Options:
             {
                 Given = { AppSettings = DetailedHelp },
                 WhenArgs = "EnumerableModel -h",
-                Then = { Result = @"Usage: dotnet testhost.dll EnumerableModel [arguments] [options]
+                Then = { Result = @"Usage: dotnet testhost.dll EnumerableModel [options] [arguments]
 
 Arguments:
 
@@ -58,7 +58,7 @@ Options:
             {
                 Given = {AppSettings = BasicHelp},
                 WhenArgs = "Enumerable -h",
-                Then = {Result = @"Usage: dotnet testhost.dll Enumerable [arguments] [options]
+                Then = {Result = @"Usage: dotnet testhost.dll Enumerable [options] [arguments]
 
 Arguments:
   args
@@ -75,7 +75,7 @@ Options:
             {
                 Given = {AppSettings = DetailedHelp},
                 WhenArgs = "Enumerable -h",
-                Then = {Result = @"Usage: dotnet testhost.dll Enumerable [arguments] [options]
+                Then = {Result = @"Usage: dotnet testhost.dll Enumerable [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/Arguments/MixedDefinedAs_MethodParamsAndArgModel_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/MixedDefinedAs_MethodParamsAndArgModel_Tests.cs
@@ -24,7 +24,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                 WhenArgs = "Do -h",
                 Then =
                 {
-                    Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
   ModelArg
@@ -47,7 +47,7 @@ Options:
             {
                 Given = { AppSettings = DetailedHelp },
                 WhenArgs = "Do -h",
-                Then = { Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                Then = { Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/Arguments/NestedArgModelTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/NestedArgModelTests.cs
@@ -21,7 +21,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
             {
                 Given = { AppSettings = BasicHelp },
                 WhenArgs = "Do -h",
-                Then = { Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                Then = { Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
   Operand1
@@ -40,7 +40,7 @@ Options:
             {
                 Given = { AppSettings = DetailedHelp },
                 WhenArgs = "Do -h",
-                Then = { Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                Then = { Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionWithDefaultMethodTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionWithDefaultMethodTests.cs
@@ -66,7 +66,7 @@ Arguments:
                     WhenArgs = "-h",
                     Then =
                     {
-                        Result = @"Usage: dotnet testhost.dll [command] [arguments] [options]
+                        Result = @"Usage: dotnet testhost.dll [command] [options] [arguments]
 
 Arguments:
 
@@ -100,7 +100,7 @@ Use ""dotnet testhost.dll [command] --help"" for more information about a comman
                     WhenArgs = "Do -h",
                     Then =
                     {
-                        Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                        Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionWithInheritedOptionsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ClassCommands/InterceptorExecutionWithInheritedOptionsTests.cs
@@ -66,7 +66,7 @@ Use ""dotnet testhost.dll [command] --help"" for more information about a comman
                     WhenArgs = "Do -h",
                     Then =
                     {
-                        Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                        Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/Help/ArgumentAttributesHelpTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Help/ArgumentAttributesHelpTests.cs
@@ -23,7 +23,7 @@ namespace CommandDotNet.Tests.FeatureTests.Help
                         WhenArgs = "Do -h",
                         Then =
                         {
-                            Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                            Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
   operand   operand-descr
@@ -45,7 +45,7 @@ Options:
                         WhenArgs = "Do -h",
                         Then =
                         {
-                            Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                            Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet.Tests/FeatureTests/Help/ExpandArgumentsInUsageTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Help/ExpandArgumentsInUsageTests.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Help
+{
+    public class ExpandArgumentsInUsageTests
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public ExpandArgumentsInUsageTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void Given_ExpandArgumentsInUsage_Then_ArgumentsAreListedByName()
+        {
+            new AppRunner<App>(new AppSettings { Help = {ExpandArgumentsInUsage = true}})
+                .VerifyScenario(_testOutputHelper, new Scenario
+                {
+                    WhenArgs = "Do -h",
+                    Then = { ResultsContainsTexts = { "Usage: dotnet testhost.dll Do <arg1> <arg2> [<optional>]" } }
+                });
+        }
+
+        [Fact]
+        public void Given_ExpandArgumentsInUsage_Then_ArgumentsAreListedAfterOptions()
+        {
+            new AppRunner<App>(new AppSettings { Help = { ExpandArgumentsInUsage = true } })
+                .VerifyScenario(_testOutputHelper, new Scenario
+                {
+                    WhenArgs = "Do2 -h",
+                    Then = { ResultsContainsTexts = { "Usage: dotnet testhost.dll Do2 [options] <arg1> <arg2> [<optional>]" } }
+                });
+        }
+
+        public class App
+        {
+            public void Do(string arg1, FileInfo arg2, string optional = "lala")
+            {
+
+            }
+
+            public void Do2(
+                string arg1, FileInfo arg2, [Option] string option1, 
+                string optional = "lala", [Option] string optionalOption = "fishies")
+            {
+
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/ParameterResolverTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParameterResolverTests.cs
@@ -24,7 +24,7 @@ namespace CommandDotNet.Tests.FeatureTests
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
                     WhenArgs = "Do -h",
-                    Then = { Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Then = { Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
   intOperand
@@ -41,7 +41,7 @@ Options:
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
                     WhenArgs = "Do -h",
-                    Then = { Result = @"Usage: dotnet testhost.dll Do [arguments] [options]
+                    Then = { Result = @"Usage: dotnet testhost.dll Do [options] [arguments]
 
 Arguments:
 

--- a/CommandDotNet/Help/AppHelpSettings.cs
+++ b/CommandDotNet/Help/AppHelpSettings.cs
@@ -16,5 +16,10 @@
         /// When specified, <see cref="UsageAppNameStyle"/> is ignored.
         /// </summary>
         public string UsageAppName { get; set; }
+
+        /// <summary>
+        /// When true, the usage section will expand arguments so the names of all arguments are shown.
+        /// </summary>
+        public bool ExpandArgumentsInUsage { get; set; }
     }
 }

--- a/CommandDotNet/Help/HelpTextProvider.cs
+++ b/CommandDotNet/Help/HelpTextProvider.cs
@@ -31,13 +31,14 @@ namespace CommandDotNet.Help
                 (null, ExtendedHelpText(command)));
 
         /// <summary>returns the body of the usage section</summary>
-        protected virtual string SectionUsage(Command command) =>
-        (
-            PadFront(command.Usage)
-            ?? $"{PadFront(AppName(command))}{PadFront(CommandPath(command))}"
-            + $"{PadFront(UsageSubcommand(command))}{PadFront(UsageOperand(command))}{PadFront(UsageOption(command))}"
-            + (_appSettings.AllowArgumentSeparator ? " [[--] <arg>...]" : null)
-        )?.Replace("%UsageAppName%", AppName(command));
+        protected virtual string SectionUsage(Command command)
+        {
+            var usage = PadFront(command.Usage)
+                           ?? $"{PadFront(AppName(command))}{PadFront(CommandPath(command))}"
+                           + $"{PadFront(UsageSubcommand(command))}{PadFront(UsageOption(command))}{PadFront(UsageOperand(command))}"
+                           + (_appSettings.AllowArgumentSeparator ? " [[--] <arg>...]" : null);
+            return usage?.Replace("%UsageAppName%", AppName(command));
+        }
 
         protected virtual string AppName(Command command) =>
             _appName ?? (_appName = command.GetAppName(_appHelpSettings));
@@ -48,7 +49,9 @@ namespace CommandDotNet.Help
         /// <summary>How operands are shown in the usage example</summary>
         protected virtual string UsageOperand(Command command) =>
             command.Operands.Any()
-                ? "[arguments]"
+                ? _appHelpSettings.ExpandArgumentsInUsage
+                    ? command.Operands.Select(o => o.Arity.Minimum == 0 ? $"[<{o.Name}>]" : $"<{o.Name}>").ToCsv(" ")
+                    : "[arguments]"
                 : null;
 
         /// <summary>How options are shown in the usage example</summary>

--- a/docs/DefiningCommands/argument-collections.md
+++ b/docs/DefiningCommands/argument-collections.md
@@ -13,7 +13,7 @@ This is what help information looks like
 ```bash
 ~
 $ dotnet example.dll LaunchRocket -h
-Usage: dotnet example.dll LaunchRocket [arguments] [options]
+Usage: dotnet example.dll LaunchRocket [options] [arguments]
 
 Arguments:
 

--- a/docs/DefiningCommands/arguments.md
+++ b/docs/DefiningCommands/arguments.md
@@ -53,7 +53,7 @@ public void LaunchRocket(
 and help looks like:
 
 ```bash
-Usage: dotnet CommandDotNet.Example.dll launch-rocket [arguments] [options]  
+Usage: dotnet CommandDotNet.Example.dll launch-rocket [options] [arguments]  
                                                                              
 Arguments:                                                                   
                                                                              

--- a/docs/Extensibility/help.md
+++ b/docs/Extensibility/help.md
@@ -12,7 +12,7 @@ The default template is as follows
 ```bash
 {description}
 
-Usage: {application} [command] [arguments] [options]
+Usage: {application} [command] [options] [arguments]
 
 Arguments:
 
@@ -57,6 +57,7 @@ new AppSettings
     Help
     {
         PrintHelpOption = true,
+        ExpandArgumentsInUsage = true,
         TextStyle = HelpTextStyle.Basic,
         UsageAppNameStyle = UsageAppNameStyle.Executable,
         UsageAppName = "GlobalToolName"
@@ -66,6 +67,18 @@ new AppSettings
 
 ### PrintHelpOption
 `PrintHelpOption` will include the help option in the list of options for every command.
+
+### ExpandArgumentsInUsage
+When true, arguments are expanded in the usage section so the names of all arguments are shown.
+
+Given the command: `Add(int value1, int value2, int value3 = 0)`
+
+Usage is `Add [arguments]` 
+
+When ExpandArgumentsInUsage = true
+
+Usage is `Add <value1> <value2> [<value3>]`
+
 
 ### TextStyle
 Default is `HelpTextStyle.Detailed`. `HelpTextStyle.Basic` changes the argument and option template to just `{name} {description}`


### PR DESCRIPTION
[options] [arguments] becomes
[options] < arg1 > < arg2 > [< optionalArg >]

closes #186