### PR TITLE
don't require a parent command for arguments

### DIFF
--- a/CommandDotNet.Tests/UnitTests/Extensions/ArgumentExtensionTests.cs
+++ b/CommandDotNet.Tests/UnitTests/Extensions/ArgumentExtensionTests.cs
@@ -13,8 +13,8 @@ namespace CommandDotNet.Tests.UnitTests.Extensions
         static ArgumentExtensionTests()
         {
             var command = new Command("cmd");
-            AnOption = new Option("option", null, command, TypeInfo.Flag, ArgumentArity.ExactlyOne);
-            AnOperand = new Operand("operand", command, TypeInfo.Single<int>(), ArgumentArity.ExactlyOne);
+            AnOption = new Option("option", null, TypeInfo.Flag, ArgumentArity.ExactlyOne);
+            AnOperand = new Operand("operand", TypeInfo.Single<int>(), ArgumentArity.ExactlyOne);
         }
 
         [Fact]

--- a/CommandDotNet/Builders/VersionMiddleware.cs
+++ b/CommandDotNet/Builders/VersionMiddleware.cs
@@ -30,7 +30,7 @@ namespace CommandDotNet.Builders
             }
 
             var option = new Option(VersionOptionName, 'v', 
-                args.CommandBuilder.Command, TypeInfo.Flag, ArgumentArity.Zero, 
+                TypeInfo.Flag, ArgumentArity.Zero, 
                 definitionSource: typeof(VersionMiddleware).FullName)
             {
                 Description = "Show version information",

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -83,8 +83,7 @@ namespace CommandDotNet.ClassModeling.Definitions
                 var operandAttr = argumentDef.CustomAttributes.GetCustomAttribute<OperandAttribute>() 
                                   ?? (INameAndDescription) argumentDef.CustomAttributes.GetCustomAttribute<ArgumentAttribute>();
                 return new Operand(
-                    argumentDef.Name, 
-                    parent, 
+                    argumentDef.Name,
                     typeInfo,
                     ArgumentArity.Default(argumentDef.Type, argumentDef.HasDefaultValue, BooleanMode.Explicit), 
                     argumentDef.SourcePath,
@@ -111,7 +110,6 @@ namespace CommandDotNet.ClassModeling.Definitions
                 return new Option(
                     longName,
                     ParseShortName(argumentDef, optionAttr?.ShortName),
-                    parent, 
                     typeInfo, 
                     argumentArity, 
                     definitionSource: argumentDef.SourcePath,

--- a/CommandDotNet/Help/HelpMiddleware.cs
+++ b/CommandDotNet/Help/HelpMiddleware.cs
@@ -25,7 +25,7 @@ namespace CommandDotNet.Help
             var appSettingsHelp = args.CommandContext.AppConfig.AppSettings.Help;
 
             var option = new Option(Constants.HelpOptionName, 'h', 
-                args.CommandBuilder.Command, TypeInfo.Flag, ArgumentArity.Zero, 
+                TypeInfo.Flag, ArgumentArity.Zero, 
                 aliases: new []{"?"}, 
                 definitionSource: typeof(HelpMiddleware).FullName)
             {

--- a/CommandDotNet/Operand.cs
+++ b/CommandDotNet/Operand.cs
@@ -12,21 +12,34 @@ namespace CommandDotNet
 {
     public sealed class Operand : IArgument
     {
+        private Command _parent;
         private object _value;
         private readonly ValueProxy _valueProxy;
 
+        [Obsolete("Use ctor without 'Command parent' parameter")]
         public Operand(
-            string name, 
-            Command parent, 
+            string name,
+            Command parent,
             TypeInfo typeInfo,
             IArgumentArity arity,
-            string definitionSource = null, 
+            string definitionSource = null,
+            ICustomAttributeProvider customAttributes = null,
+            ValueProxy valueProxy = null)
+            : this(name, typeInfo, arity, definitionSource, customAttributes, valueProxy)
+        {
+            _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+        }
+
+        public Operand(
+            string name,
+            TypeInfo typeInfo,
+            IArgumentArity arity,
+            string definitionSource = null,
             ICustomAttributeProvider customAttributes = null,
             ValueProxy valueProxy = null)
         {
             _valueProxy = valueProxy;
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            Parent = parent ?? throw new ArgumentNullException(nameof(parent));
             TypeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             Arity = arity ?? throw new ArgumentNullException(nameof(arity));
             DefinitionSource = definitionSource;
@@ -77,7 +90,18 @@ namespace CommandDotNet
         }
 
         /// <summary>The <see cref="Command"/> that hosts this <see cref="Operand"/></summary>
-        public Command Parent { get; }
+        public Command Parent
+        {
+            get => _parent;
+            set
+            {
+                if (_parent != null && _parent != value)
+                {
+                    throw new InvalidConfigurationException($"{nameof(Parent)} is already assigned for {this}.  Current={_parent} New={value}");
+                }
+                _parent = value;
+            }
+        }
 
         /// <summary>The aliases defined for this argument</summary>
         public IReadOnlyCollection<string> Aliases { get; }

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -13,15 +13,34 @@ namespace CommandDotNet
 {
     public sealed class Option : IArgument
     {
+        private Command _parent;
         private object _value;
         private readonly ValueProxy _valueProxy;
 
         private readonly HashSet<string> _aliases;
-        
+
+        [Obsolete("Use ctor without 'Command parent' parameter")]
         public Option(
             string longName,
             char? shortName,
             Command parent,
+            TypeInfo typeInfo,
+            IArgumentArity arity,
+            string definitionSource = null,
+            IEnumerable<string> aliases = null,
+            ICustomAttributeProvider customAttributes = null,
+            bool isInterceptorOption = false,
+            bool assignToExecutableSubcommands = false,
+            ValueProxy valueProxy = null)
+            : this(longName, shortName, typeInfo, arity, definitionSource, aliases, customAttributes,
+                isInterceptorOption, assignToExecutableSubcommands, valueProxy)
+        {
+            _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+        }
+
+        public Option(
+            string longName,
+            char? shortName,
             TypeInfo typeInfo,
             IArgumentArity arity,
             string definitionSource = null,
@@ -44,7 +63,6 @@ namespace CommandDotNet
 
             _valueProxy = valueProxy;
 
-            Parent = parent ?? throw new ArgumentNullException(nameof(parent));
             TypeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             Arity = arity ?? throw new ArgumentNullException(nameof(arity));
             DefinitionSource = definitionSource;
@@ -70,7 +88,18 @@ namespace CommandDotNet
         public string LongName { get; }
 
         /// <summary>The <see cref="Command"/> that hosts this <see cref="Option"/></summary>
-        public Command Parent { get; }
+        public Command Parent
+        {
+            get => _parent;
+            set
+            {
+                if (_parent != null && _parent != value)
+                {
+                    throw new InvalidConfigurationException($"{nameof(Parent)} is already assigned for {this}.  Current={_parent} New={value}");
+                }
+                _parent = value;
+            }
+        }
 
         /// <summary>The aliases defined for this argument</summary>
         public IReadOnlyCollection<string> Aliases => _aliases;


### PR DESCRIPTION
this makes it easier to add them in build events
and we can ensure the command is the one they
are added to