### PR TITLE
check mis-ordered keywords in typo suggestions

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/TypoSuggestions_GetSuggestions_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/TypoSuggestions_GetSuggestions_Tests.cs
@@ -68,5 +68,16 @@ namespace CommandDotNet.Tests.FeatureTests
                 .Should()
                 .BeEquivalentSequenceTo(expectedSuggestions);
         }
+
+        [Theory]
+        [InlineData("nameuser", "username,password", "username")]
+        [InlineData("treework", "worktree,trek", "worktree,trek")]
+        public void GivenWordsInWrongOrder(string typo, string options, string expectedSuggestions)
+        {
+            options.Split(",")
+                .GetSuggestions(typo, 5)
+                .Should()
+                .BeEquivalentSequenceTo(expectedSuggestions.Split(","));
+        }
     }
 }


### PR DESCRIPTION
i.e. nameuser -> username or treework -> worktree