### PR TITLE
upgrade FluentValidation to v8

### DIFF
--- a/CommandDotNet.Example/CommandDotNet.Example.csproj
+++ b/CommandDotNet.Example/CommandDotNet.Example.csproj
@@ -11,7 +11,8 @@
     <ProjectReference Include="..\CommandDotNet\CommandDotNet.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="7.6.103" />
+    <PackageReference Include="FluentValidation" Version="8.0.0" />
+    <PackageReference Include="FluentValidation.ValidatorAttribute" Version="8.0.0" />
     <PackageReference Include="Humanizer.Core" Version="2.7.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />

--- a/CommandDotNet.FluentValidation/CommandDotNet.FluentValidation.csproj
+++ b/CommandDotNet.FluentValidation/CommandDotNet.FluentValidation.csproj
@@ -36,7 +36,8 @@
     <None Remove="output\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="7.6.103" />
+    <PackageReference Include="FluentValidation" Version="8.0.0" />
+    <PackageReference Include="FluentValidation.ValidatorAttribute" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CommandDotNet\CommandDotNet.csproj" />

--- a/CommandDotNet.Tests/CommandDotNet.Tests.csproj
+++ b/CommandDotNet.Tests/CommandDotNet.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="FluentValidation" Version="7.6.103" />
+    <PackageReference Include="FluentValidation" Version="8.0.0" />
     <PackageReference Include="JsonDiffPatch.Net" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
add FluentValidation.Attributes dependency to keep using
ValidatorAttribute

https://docs.fluentvalidation.net/en/latest/upgrading-to-8.html#validatorattribute-and-attributedvalidatorfactory-have-been-moved-to-a-separate-package