### PR TITLE
breaking: add DefaultValue type with source and key

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromAppSettingsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromAppSettingsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using CommandDotNet.Extensions;
+using CommandDotNet.TestTools;
 using CommandDotNet.TestTools.Scenarios;
 using Xunit;
 using Xunit.Abstractions;
@@ -173,9 +174,31 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
+        [Theory]
+        [InlineData("List", "planets", "mars,pluto")]
+        [InlineData("List", "planets", "mars")]
+        public void CsvValues(string args, string key, string value)
+        {
+            var nvc = new NameValueCollection
+            {
+                {key, value}
+            };
+
+            var scenario = new Scenario
+            {
+                WhenArgs = args,
+                Then = { Outputs = { value.Split(",") }}
+            };
+
+            new AppRunner<App>()
+                .UseDefaultsFromAppSetting(nvc, includeNamingConventions: true)
+                .VerifyScenario(_testOutputHelper, scenario);
+        }
 
         public class App
         {
+            private TestOutputs TestOutputs { get; set; }
+
             public void ByConvention(
                 [Option(LongName = "option1", ShortName = "o")] string option1,
                 [Operand] string operand1,
@@ -195,6 +218,11 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             )
             {
 
+            }
+
+            public void List(string[] planets)
+            {
+                TestOutputs.CaptureIfNotNull(planets);
             }
         }
     }

--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromEnvVarsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromEnvVarsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
-using CommandDotNet.Tests.FeatureTests.EnabledMiddlewareScenarios;
+using System.Collections.Specialized;
+using CommandDotNet.TestTools;
 using CommandDotNet.TestTools.Scenarios;
 using Xunit;
 using Xunit.Abstractions;
@@ -54,8 +55,31 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
+        [Theory]
+        [InlineData("List", "planets", "mars,pluto")]
+        [InlineData("List", "planets", "mars")]
+        public void CsvValues(string args, string key, string value)
+        {
+            var nvc = new NameValueCollection
+            {
+                {key, value}
+            };
+
+            var scenario = new Scenario
+            {
+                WhenArgs = args,
+                Then = { Outputs = { value.Split(",") } }
+            };
+
+            new AppRunner<App>()
+                .UseDefaultsFromAppSetting(nvc, includeNamingConventions: true)
+                .VerifyScenario(_testOutputHelper, scenario);
+        }
+
         public class App
         {
+            private TestOutputs TestOutputs { get; set; }
+
             public void ByAttribute(
                 [EnvVar("opt1")] [Option(LongName = "option1", ShortName = "o")]
                 string option1,
@@ -66,6 +90,11 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             )
             {
 
+            }
+
+            public void List(string[] planets)
+            {
+                TestOutputs.CaptureIfNotNull(planets);
             }
         }
     }

--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/UseDefaultsFromConfigTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/UseDefaultsFromConfigTests.cs
@@ -24,7 +24,7 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red")
+                .UseDefaultsFromConfig(arg => Config("red"))
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
@@ -38,7 +38,7 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red")
+                .UseDefaultsFromConfig(arg => Config("red"))
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
@@ -52,21 +52,7 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red,blue,green")
-                .VerifyScenario(_testOutputHelper, scenario);
-        }
-
-        [Fact]
-        public void GivenCsvValue_Should_SplitAsDefaultForCollectionArgument()
-        {
-            var scenario = new Scenario
-            {
-                WhenArgs = "List",
-                Then = { Outputs = { new []{ "red", "blue", "green" } } }
-            };
-
-            new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red,blue,green")
+                .UseDefaultsFromConfig(arg => Config("red,blue,green"))
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
@@ -84,6 +70,11 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             new AppRunner<App>()
                 .UseDefaultsFromConfig(arg => null)
                 .VerifyScenario(_testOutputHelper, scenario);
+        }
+
+        private static DefaultValue Config(string value)
+        {
+            return new DefaultValue("test", "key", value);
         }
 
         public class App

--- a/CommandDotNet.Tests/FeatureTests/EnabledMiddlewareScenarios/SetDefaultsTestMiddleware.cs
+++ b/CommandDotNet.Tests/FeatureTests/EnabledMiddlewareScenarios/SetDefaultsTestMiddleware.cs
@@ -43,7 +43,7 @@ namespace CommandDotNet.Tests.FeatureTests.EnabledMiddlewareScenarios
             { 
                 if (defaults.TryGetValue(argument.Name, out var value))
                 {
-                    argument.DefaultValue = value;
+                    argument.DefaultValue = new DefaultValue("test", "lala", value);
                 }
             }
 

--- a/CommandDotNet/ArgumentArity.cs
+++ b/CommandDotNet/ArgumentArity.cs
@@ -50,7 +50,7 @@ namespace CommandDotNet
         public static IArgumentArity Default(IArgument argument)
         {
             var type = argument.TypeInfo.Type;
-            var hasDefaultValue = argument.DefaultValue != null && !argument.DefaultValue.IsDefaultFor(type);
+            var hasDefaultValue = argument.DefaultValue != null && !argument.DefaultValue.Value.IsDefaultFor(type);
             return Default(type, hasDefaultValue, argument.Services.Get<BooleanMode>());
         }
 

--- a/CommandDotNet/Builders/ArgumentDefaults/SetArgumentDefaultsMiddleware.cs
+++ b/CommandDotNet/Builders/ArgumentDefaults/SetArgumentDefaultsMiddleware.cs
@@ -7,13 +7,15 @@ namespace CommandDotNet.Builders.ArgumentDefaults
 {
     internal static class SetArgumentDefaultsMiddleware
     {
-        internal static AppRunner SetArgumentDefaultsFrom(AppRunner appRunner, Func<IArgument, string>[] getDefaultValueCallbacks)
+        internal static AppRunner SetArgumentDefaultsFrom(AppRunner appRunner, string sourceName, 
+            Func<IArgument, DefaultValue>[] getDefaultValueCallbacks)
         {
             // run before help command so help will display the updated defaults
             return appRunner.Configure(c =>
             {
                 var config = new Config
                 {
+                    SourceName = sourceName,
                     GetDefaultValueCallbacks = getDefaultValueCallbacks
                 };
                 c.Services.AddOrUpdate(config);
@@ -40,14 +42,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
                 var value = config.GetDefaultValueCallbacks.Select(func => func(argument)).FirstOrDefault();
                 if (value != null)
                 {
-                    if (argument.Arity.AllowsMany())
-                    {
-                        argument.DefaultValue = value.Split(',');
-                    }
-                    else
-                    {
-                        argument.DefaultValue = value;
-                    }
+                    argument.DefaultValue = value;
                 }
             }
 
@@ -56,7 +51,8 @@ namespace CommandDotNet.Builders.ArgumentDefaults
 
         private class Config
         {
-            public Func<IArgument, string>[] GetDefaultValueCallbacks { get; set; }
+            public string SourceName { get; set; }
+            public Func<IArgument, DefaultValue>[] GetDefaultValueCallbacks { get; set; }
         }
     }
 }

--- a/CommandDotNet/ClassModeling/BindValuesMiddleware.cs
+++ b/CommandDotNet/ClassModeling/BindValuesMiddleware.cs
@@ -49,9 +49,9 @@ namespace CommandDotNet.ClassModeling
                         return Task.FromResult(returnCode);
                     }
                 }
-                else if (argument.DefaultValue != null)
+                else if (argument.DefaultValue?.Value != null)
                 {
-                    var defaultValue = argument.DefaultValue;
+                    var defaultValue = argument.DefaultValue.Value;
                     // middleware could set the default to any type.
                     // string values could be assigned from attributes or config values
                     // so they are parsed as if submitted from the shell.

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -76,7 +76,9 @@ namespace CommandDotNet.ClassModeling.Definitions
             TypeInfo typeInfo,
             bool isInterceptorOption)
         {
-            var defaultValue = argumentDef.HasDefaultValue ? argumentDef.DefaultValue : null;
+            var defaultValue = argumentDef.HasDefaultValue && !argumentDef.DefaultValue.IsNullValue()
+                ? new DefaultValue(argumentDef.ArgumentDefType, argumentDef.SourcePath, argumentDef.DefaultValue) 
+                : null;
 
             if (argumentDef.CommandNodeType == CommandNodeType.Operand)
             {

--- a/CommandDotNet/ClassModeling/Definitions/IArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/IArgumentDef.cs
@@ -4,6 +4,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 {
     internal interface IArgumentDef: ISourceDef
     {
+        string ArgumentDefType { get; }
         CommandNodeType CommandNodeType { get; }
         Type Type { get; }
         bool HasDefaultValue { get; }

--- a/CommandDotNet/ClassModeling/Definitions/ParameterArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/ParameterArgumentDef.cs
@@ -9,6 +9,8 @@ namespace CommandDotNet.ClassModeling.Definitions
     {
         private readonly ParameterInfo _parameterInfo;
 
+        public string ArgumentDefType => "Parameter";
+
         public CommandNodeType CommandNodeType { get; }
 
         public string Name { get; }

--- a/CommandDotNet/ClassModeling/Definitions/PropertyArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/PropertyArgumentDef.cs
@@ -9,6 +9,8 @@ namespace CommandDotNet.ClassModeling.Definitions
     {
         private readonly PropertyInfo _propertyInfo;
 
+        public string ArgumentDefType => "Property";
+
         public PropertyArgumentDef(
             PropertyInfo propertyInfo,
             CommandNodeType commandNodeType,

--- a/CommandDotNet/DefaultValue.cs
+++ b/CommandDotNet/DefaultValue.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace CommandDotNet
+{
+    /// <summary>The values provided as the default for an argument</summary>
+    public class DefaultValue
+    {
+        /// <summary>The source of the default value</summary>
+        public string Source { get; }
+
+        /// <summary>The key of the default value</summary>
+        public string Key { get; }
+
+        /// <summary>The text values</summary>
+        public object Value { get; }
+
+        public DefaultValue(string source, string key, object value)
+        {
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public override string ToString()
+        {
+            // do not include value in case it's a password
+            return $"{nameof(DefaultValue)}: {Source}.{Key}";
+        }
+    }
+}

--- a/CommandDotNet/Help/HelpTextProvider.cs
+++ b/CommandDotNet/Help/HelpTextProvider.cs
@@ -185,7 +185,7 @@ namespace CommandDotNet.Help
         /// <summary></summary>
         protected virtual string ArgumentDefaultValue(IArgument argument)
         {
-            object defaultValue = argument.DefaultValue;
+            object defaultValue = argument.DefaultValue?.Value;
 
             if (defaultValue.IsNullValue())
             {

--- a/CommandDotNet/IArgument.cs
+++ b/CommandDotNet/IArgument.cs
@@ -14,7 +14,7 @@ namespace CommandDotNet
         IArgumentArity Arity { get; set; }
 
         /// <summary>The default value for this argument</summary>
-        object DefaultValue { get; set; }
+        DefaultValue DefaultValue { get; set; }
 
         /// <summary>
         /// The allowed values for this argument, as defined by an <see cref="IAllowedValuesTypeDescriptor"/> for this type.

--- a/CommandDotNet/Operand.cs
+++ b/CommandDotNet/Operand.cs
@@ -55,9 +55,9 @@ namespace CommandDotNet
 
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
-
+        
         /// <summary>The default value for this argument</summary>
-        public object DefaultValue { get; set; }
+        public DefaultValue DefaultValue { get; set; }
 
         /// <summary>
         /// The allowed values for this argument, as defined by an <see cref="IAllowedValuesTypeDescriptor"/> for this type.

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -117,7 +117,7 @@ namespace CommandDotNet
         public IArgumentArity Arity { get; set; }
 
         /// <summary>The default value for this argument</summary>
-        public object DefaultValue { get; set; } = DBNull.Value;
+        public DefaultValue DefaultValue { get; set; }
 
         /// <summary>
         /// The allowed values for this argument, as defined by an <see cref="IAllowedValuesTypeDescriptor"/> for this type.
@@ -128,7 +128,7 @@ namespace CommandDotNet
         /// <summary>
         /// The text values provided as input.
         /// Will be empty if no values were provided.<br/>
-        /// Sources provided by this framework can be found at <see cref="Constants.InputValueSources"/><br/>
+        /// Sources provided by this framework are named in the constants class <see cref="Constants.InputValueSources"/><br/>
         /// Flag options will contain a bool value.
         /// </summary>
         public ICollection<InputValue> InputValues { get; } = new List<InputValue>();

--- a/CommandDotNet/Prompts/ValuePromptMiddleware.cs
+++ b/CommandDotNet/Prompts/ValuePromptMiddleware.cs
@@ -79,7 +79,7 @@ namespace CommandDotNet.Prompts
                     option => !option.Arity.AllowsNone() // exclude flag options: help, version, ...
                 ))
                 .Where(a => argumentFilter == null || argumentFilter(a))
-                .Where(a => a.InputValues.IsEmpty() && a.DefaultValue.IsNullValue())
+                .Where(a => a.InputValues.IsEmpty() && (a.DefaultValue?.Value.IsNullValue() ?? true))
                 .TakeWhile(a => !commandContext.AppConfig.CancellationToken.IsCancellationRequested && !isCancellationRequested)
                 .ForEach(a =>
                 {


### PR DESCRIPTION
This makes it easy to track the source of default values.

Middleware and Help providers can take advantage of this
for logging and troubleshooting.