### PR TITLE
add DefaultValue type with source and key

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromAppSettingsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromAppSettingsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using CommandDotNet.Extensions;
+using CommandDotNet.TestTools;
 using CommandDotNet.TestTools.Scenarios;
 using Xunit;
 using Xunit.Abstractions;
@@ -173,9 +174,31 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
+        [Theory]
+        [InlineData("List", "planets", "mars,pluto")]
+        [InlineData("List", "planets", "mars")]
+        public void CsvValues(string args, string key, string value)
+        {
+            var nvc = new NameValueCollection
+            {
+                {key, value}
+            };
+
+            var scenario = new Scenario
+            {
+                WhenArgs = args,
+                Then = { Outputs = { value.Split(",") } }
+            };
+
+            new AppRunner<App>()
+                .UseDefaultsFromAppSetting(nvc, includeNamingConventions: true)
+                .VerifyScenario(_testOutputHelper, scenario);
+        }
 
         public class App
         {
+            private TestOutputs TestOutputs { get; set; }
+
             public void ByConvention(
                 [Option(LongName = "option1", ShortName = "o")] string option1,
                 [Operand] string operand1,
@@ -195,6 +218,11 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             )
             {
 
+            }
+
+            public void List(string[] planets)
+            {
+                TestOutputs.CaptureIfNotNull(planets);
             }
         }
     }

--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromEnvVarsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromEnvVarsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
-using CommandDotNet.Tests.FeatureTests.EnabledMiddlewareScenarios;
+using System.Collections.Specialized;
+using CommandDotNet.TestTools;
 using CommandDotNet.TestTools.Scenarios;
 using Xunit;
 using Xunit.Abstractions;
@@ -54,8 +55,31 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
+        [Theory]
+        [InlineData("List", "planets", "mars,pluto")]
+        [InlineData("List", "planets", "mars")]
+        public void CsvValues(string args, string key, string value)
+        {
+            var nvc = new NameValueCollection
+            {
+                {key, value}
+            };
+
+            var scenario = new Scenario
+            {
+                WhenArgs = args,
+                Then = { Outputs = { value.Split(",") } }
+            };
+
+            new AppRunner<App>()
+                .UseDefaultsFromAppSetting(nvc, includeNamingConventions: true)
+                .VerifyScenario(_testOutputHelper, scenario);
+        }
+
         public class App
         {
+            private TestOutputs TestOutputs { get; set; }
+
             public void ByAttribute(
                 [EnvVar("opt1")] [Option(LongName = "option1", ShortName = "o")]
                 string option1,
@@ -66,6 +90,11 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             )
             {
 
+            }
+
+            public void List(string[] planets)
+            {
+                TestOutputs.CaptureIfNotNull(planets);
             }
         }
     }

--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/UseDefaultsFromConfigTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/UseDefaultsFromConfigTests.cs
@@ -1,4 +1,5 @@
-﻿using CommandDotNet.TestTools;
+﻿using System;
+using CommandDotNet.TestTools;
 using CommandDotNet.TestTools.Scenarios;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,7 +25,7 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red")
+                .UseDefaultsFromConfig(arg => Config("red"))
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
@@ -38,7 +39,7 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red")
+                .UseDefaultsFromConfig(arg => Config("red"))
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
@@ -52,21 +53,7 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red,blue,green")
-                .VerifyScenario(_testOutputHelper, scenario);
-        }
-
-        [Fact]
-        public void GivenCsvValue_Should_SplitAsDefaultForCollectionArgument()
-        {
-            var scenario = new Scenario
-            {
-                WhenArgs = "List",
-                Then = { Outputs = { new []{ "red", "blue", "green" } } }
-            };
-
-            new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => "red,blue,green")
+                .UseDefaultsFromConfig(arg => Config("red,blue,green"))
                 .VerifyScenario(_testOutputHelper, scenario);
         }
 
@@ -82,8 +69,13 @@ namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
             };
 
             new AppRunner<App>()
-                .UseDefaultsFromConfig(arg => null)
+                .UseDefaultsFromConfig(new Func<IArgument, ArgumentDefault>(arg => null))
                 .VerifyScenario(_testOutputHelper, scenario);
+        }
+
+        private static ArgumentDefault Config(string value)
+        {
+            return new ArgumentDefault("test", "key", value);
         }
 
         public class App

--- a/CommandDotNet.Tests/FeatureTests/EnabledMiddlewareScenarios/SetDefaultsTestMiddleware.cs
+++ b/CommandDotNet.Tests/FeatureTests/EnabledMiddlewareScenarios/SetDefaultsTestMiddleware.cs
@@ -43,7 +43,7 @@ namespace CommandDotNet.Tests.FeatureTests.EnabledMiddlewareScenarios
             { 
                 if (defaults.TryGetValue(argument.Name, out var value))
                 {
-                    argument.DefaultValue = value;
+                    argument.Default = new ArgumentDefault("tests", "", value);
                 }
             }
 

--- a/CommandDotNet/AppRunnerConfigExtensions.cs
+++ b/CommandDotNet/AppRunnerConfigExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using CommandDotNet.Builders;
 using CommandDotNet.Builders.ArgumentDefaults;
 using CommandDotNet.ClassModeling.Definitions;
@@ -199,9 +200,20 @@ namespace CommandDotNet
                 DefaultSources.EnvVar.GetDefaultValue(envVars, DefaultSources.EnvVar.GetKeyFromAttribute));
         }
 
-        /// <summary>Provide your own strategies for setting argument defaults from a configuration source</summary>
+        [Obsolete("Use the UseDefaultsFromConfig that returns ArgumentDefaults")]
         public static AppRunner UseDefaultsFromConfig(this AppRunner appRunner,
             params Func<IArgument, string>[] getDefaultValueCallbacks)
+        {
+            Func<IArgument, ArgumentDefault> Convert(Func<IArgument, string> function)
+            {
+                return arg => new ArgumentDefault("UseDefaultsFromConfig", "", function(arg));
+            }
+            return UseDefaultsFromConfig(appRunner, getDefaultValueCallbacks.Select(Convert).ToArray());
+        }
+
+        /// <summary>Provide your own strategies for setting argument defaults from a configuration source</summary>
+        public static AppRunner UseDefaultsFromConfig(this AppRunner appRunner,
+            params Func<IArgument, ArgumentDefault>[] getDefaultValueCallbacks)
             => SetArgumentDefaultsMiddleware.SetArgumentDefaultsFrom(appRunner, getDefaultValueCallbacks);
 
         /// <summary>

--- a/CommandDotNet/ArgumentArity.cs
+++ b/CommandDotNet/ArgumentArity.cs
@@ -50,7 +50,8 @@ namespace CommandDotNet
         public static IArgumentArity Default(IArgument argument)
         {
             var type = argument.TypeInfo.Type;
-            var hasDefaultValue = argument.DefaultValue != null && !argument.DefaultValue.IsDefaultFor(type);
+            var defaultValue = argument.Default?.Value;
+            var hasDefaultValue = defaultValue != null && !defaultValue.IsDefaultFor(type);
             return Default(type, hasDefaultValue, argument.Services.Get<BooleanMode>());
         }
 

--- a/CommandDotNet/ArgumentDefault.cs
+++ b/CommandDotNet/ArgumentDefault.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace CommandDotNet
+{
+    /// <summary>The values provided as the default for an argument</summary>
+    public class ArgumentDefault
+    {
+        /// <summary>The source of the default value</summary>
+        public string Source { get; }
+
+        /// <summary>The key of the default value</summary>
+        public string Key { get; }
+
+        /// <summary>The text values</summary>
+        public object Value { get; }
+
+        public ArgumentDefault(string source, string key, object value)
+        {
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public override string ToString()
+        {
+            // do not include value in case it's a password
+            return $"{nameof(ArgumentDefault)}: {Source}.{Key}";
+        }
+    }
+}

--- a/CommandDotNet/Builders/ArgumentDefaults/DefaultSources.cs
+++ b/CommandDotNet/Builders/ArgumentDefaults/DefaultSources.cs
@@ -23,7 +23,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
                 }
             }
 
-            public static Func<IArgument, string> GetDefaultValue(
+            public static Func<IArgument, ArgumentDefault> GetDefaultValue(
                 IDictionary envVars = null,
                 params GetArgumentKeysDelegate[] getKeysDelegates)
             {
@@ -67,7 +67,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
                 }
             }
 
-            public static Func<IArgument, string> GetDefaultValue(
+            public static Func<IArgument, ArgumentDefault> GetDefaultValue(
                 NameValueCollection appSettings,
                 params GetArgumentKeysDelegate[] getKeysCallbacks)
             {
@@ -82,7 +82,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
             }
         }
 
-        private static Func<IArgument, string> GetValue(
+        private static Func<IArgument, ArgumentDefault> GetValue(
             string sourceName,
             GetArgumentKeysDelegate[] getKeys, 
             Func<string, string> getValueFromSource)
@@ -92,14 +92,23 @@ namespace CommandDotNet.Builders.ArgumentDefaults
                 var value = getKeys
                     .SelectMany(cb => cb(argument))
                     .Select(key => (key, value:getValueFromSource(key)))
-                    .FirstOrDefault(v => v.value != null);
-                
-                if (value.value != null)
+                    .Where(v => v.value != null)
+                    .Select(v =>
+                    {
+                        object f = argument.Arity.AllowsMany()
+                            ? v.value.Split(',')
+                            : (object)v.value;
+                        return new ArgumentDefault(sourceName, v.key, f);
+                    })
+                    .FirstOrDefault();
+
+                if (value != null)
                 {
-                    Log.Debug($"found default value `{value}` in `{sourceName}` for `{argument}`");
+                    // do not include value in case it's a password
+                    Log.Debug($"found default value `{value}` for `{argument}`");
                 }
 
-                return value.value;
+                return value;
             };
         }
     }

--- a/CommandDotNet/Builders/ArgumentDefaults/SetArgumentDefaultsMiddleware.cs
+++ b/CommandDotNet/Builders/ArgumentDefaults/SetArgumentDefaultsMiddleware.cs
@@ -7,7 +7,8 @@ namespace CommandDotNet.Builders.ArgumentDefaults
 {
     internal static class SetArgumentDefaultsMiddleware
     {
-        internal static AppRunner SetArgumentDefaultsFrom(AppRunner appRunner, Func<IArgument, string>[] getDefaultValueCallbacks)
+        internal static AppRunner SetArgumentDefaultsFrom(AppRunner appRunner, 
+            Func<IArgument, ArgumentDefault>[] getDefaultValueCallbacks)
         {
             // run before help command so help will display the updated defaults
             return appRunner.Configure(c =>
@@ -40,14 +41,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
                 var value = config.GetDefaultValueCallbacks.Select(func => func(argument)).FirstOrDefault();
                 if (value != null)
                 {
-                    if (argument.Arity.AllowsMany())
-                    {
-                        argument.DefaultValue = value.Split(',');
-                    }
-                    else
-                    {
-                        argument.DefaultValue = value;
-                    }
+                    argument.Default = value;
                 }
             }
 
@@ -56,7 +50,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
 
         private class Config
         {
-            public Func<IArgument, string>[] GetDefaultValueCallbacks { get; set; }
+            public Func<IArgument, ArgumentDefault>[] GetDefaultValueCallbacks { get; set; }
         }
     }
 }

--- a/CommandDotNet/ClassModeling/BindValuesMiddleware.cs
+++ b/CommandDotNet/ClassModeling/BindValuesMiddleware.cs
@@ -49,9 +49,9 @@ namespace CommandDotNet.ClassModeling
                         return Task.FromResult(returnCode);
                     }
                 }
-                else if (argument.DefaultValue != null)
+                else if (argument.Default != null)
                 {
-                    var defaultValue = argument.DefaultValue;
+                    var defaultValue = argument.Default.Value;
                     // middleware could set the default to any type.
                     // string values could be assigned from attributes or config values
                     // so they are parsed as if submitted from the shell.

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -76,7 +76,9 @@ namespace CommandDotNet.ClassModeling.Definitions
             TypeInfo typeInfo,
             bool isInterceptorOption)
         {
-            var defaultValue = argumentDef.HasDefaultValue ? argumentDef.DefaultValue : null;
+            var defaultValue = argumentDef.HasDefaultValue && !argumentDef.DefaultValue.IsNullValue()
+                ? new ArgumentDefault(argumentDef.ArgumentDefType, argumentDef.SourcePath, argumentDef.DefaultValue)
+                : null;
 
             if (argumentDef.CommandNodeType == CommandNodeType.Operand)
             {
@@ -91,7 +93,7 @@ namespace CommandDotNet.ClassModeling.Definitions
                     argumentDef.ValueProxy)
                 {
                     Description = operandAttr?.Description,
-                    DefaultValue = defaultValue
+                    Default = defaultValue
                 };
             }
             
@@ -119,7 +121,7 @@ namespace CommandDotNet.ClassModeling.Definitions
                     valueProxy: argumentDef.ValueProxy)
                 {
                     Description = optionAttr?.Description,
-                    DefaultValue = defaultValue
+                    Default = defaultValue
                 };
             }
 

--- a/CommandDotNet/ClassModeling/Definitions/IArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/IArgumentDef.cs
@@ -4,6 +4,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 {
     internal interface IArgumentDef: ISourceDef
     {
+        string ArgumentDefType { get; }
         CommandNodeType CommandNodeType { get; }
         Type Type { get; }
         bool HasDefaultValue { get; }

--- a/CommandDotNet/ClassModeling/Definitions/ParameterArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/ParameterArgumentDef.cs
@@ -9,6 +9,8 @@ namespace CommandDotNet.ClassModeling.Definitions
     {
         private readonly ParameterInfo _parameterInfo;
 
+        public string ArgumentDefType => "Parameter";
+
         public CommandNodeType CommandNodeType { get; }
 
         public string Name { get; }

--- a/CommandDotNet/ClassModeling/Definitions/PropertyArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/PropertyArgumentDef.cs
@@ -9,6 +9,8 @@ namespace CommandDotNet.ClassModeling.Definitions
     {
         private readonly PropertyInfo _propertyInfo;
 
+        public string ArgumentDefType => "Property";
+
         public PropertyArgumentDef(
             PropertyInfo propertyInfo,
             CommandNodeType commandNodeType,

--- a/CommandDotNet/Help/HelpTextProvider.cs
+++ b/CommandDotNet/Help/HelpTextProvider.cs
@@ -185,7 +185,7 @@ namespace CommandDotNet.Help
         /// <summary></summary>
         protected virtual string ArgumentDefaultValue(IArgument argument)
         {
-            object defaultValue = argument.DefaultValue;
+            object defaultValue = argument.Default?.Value;
 
             if (defaultValue.IsNullValue())
             {

--- a/CommandDotNet/IArgument.cs
+++ b/CommandDotNet/IArgument.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using CommandDotNet.Builders;
 using CommandDotNet.TypeDescriptors;
 
@@ -13,8 +14,11 @@ namespace CommandDotNet
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         IArgumentArity Arity { get; set; }
 
-        /// <summary>The default value for this argument</summary>
+        [Obsolete("Use Default instead. This enable middleware and custom help providers to report the source of a default value")]
         object DefaultValue { get; set; }
+
+        /// <summary>The default value for this argument</summary>
+        ArgumentDefault Default { get; set; }
 
         /// <summary>
         /// The allowed values for this argument, as defined by an <see cref="IAllowedValuesTypeDescriptor"/> for this type.

--- a/CommandDotNet/Operand.cs
+++ b/CommandDotNet/Operand.cs
@@ -56,8 +56,17 @@ namespace CommandDotNet
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
 
+        [Obsolete("Use Default instead. This enable middleware and custom help providers to report the source of a default value")]
+        public object DefaultValue
+        {
+            get => Default?.Value; 
+            set => Default = value == null
+                ? null
+                : new ArgumentDefault($"{nameof(Operand)}.{nameof(DefaultValue)}", "", value);
+        }
+
         /// <summary>The default value for this argument</summary>
-        public object DefaultValue { get; set; }
+        public ArgumentDefault Default { get; set; }
 
         /// <summary>
         /// The allowed values for this argument, as defined by an <see cref="IAllowedValuesTypeDescriptor"/> for this type.

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -116,8 +116,17 @@ namespace CommandDotNet
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
 
+        [Obsolete("Use Default instead. This enable middleware and custom help providers to report the source of a default value")]
+        public object DefaultValue
+        {
+            get => Default?.Value;
+            set => Default = value == null 
+                ? null 
+                : new ArgumentDefault($"{nameof(Option)}.{nameof(DefaultValue)}", "", value);
+        }
+
         /// <summary>The default value for this argument</summary>
-        public object DefaultValue { get; set; } = DBNull.Value;
+        public ArgumentDefault Default { get; set; }
 
         /// <summary>
         /// The allowed values for this argument, as defined by an <see cref="IAllowedValuesTypeDescriptor"/> for this type.

--- a/CommandDotNet/Prompts/ValuePromptMiddleware.cs
+++ b/CommandDotNet/Prompts/ValuePromptMiddleware.cs
@@ -79,7 +79,7 @@ namespace CommandDotNet.Prompts
                     option => !option.Arity.AllowsNone() // exclude flag options: help, version, ...
                 ))
                 .Where(a => argumentFilter == null || argumentFilter(a))
-                .Where(a => a.InputValues.IsEmpty() && a.DefaultValue.IsNullValue())
+                .Where(a => a.InputValues.IsEmpty() && (a.Default?.Value.IsNullValue() ?? true))
                 .TakeWhile(a => !commandContext.AppConfig.CancellationToken.IsCancellationRequested && !isCancellationRequested)
                 .ForEach(a =>
                 {

--- a/docs/Middleware/default-values-from-config.md
+++ b/docs/Middleware/default-values-from-config.md
@@ -137,7 +137,7 @@ new AppRunner<MyApp>
                           .GetCustomAttribute<GitConfigAttribute>()
                           ?.Key
         return key != null && _gitConfigService.TryGetValue(key, out var value)
-            ? value
+            ? new ArgumentDefault("git-config", key, value)
             : null;
     }
     .Run(args);


### PR DESCRIPTION
This makes it easy to track the source of default values.

Middleware and Help providers can take advantage of this
for logging and troubleshooting.