### PR TITLE
replace VersionInfo w/ AppInfo. ++ self-contained.exe logic

### DIFF
--- a/CommandDotNet.GitHubReleases/AlertOnNewerReleaseMiddleware.cs
+++ b/CommandDotNet.GitHubReleases/AlertOnNewerReleaseMiddleware.cs
@@ -89,8 +89,8 @@ namespace CommandDotNet.NewerReleasesAlerts
 
         private static bool TryGetCurrentVersion(CommandContext context, out SemVersion semVersion)
         {
-            var versionInfo = VersionInfo.GetVersionInfo(context);
-            return SemVersion.TryParse(versionInfo.Version, out semVersion);
+            var appInfo = AppInfo.GetAppInfo(context);
+            return SemVersion.TryParse(appInfo.Version, out semVersion);
 
         }
 

--- a/CommandDotNet.Tests/CommandDotNet.NewerReleasesAlerts/NewReleaseAlertOnGitHubTests.cs
+++ b/CommandDotNet.Tests/CommandDotNet.NewerReleasesAlerts/NewReleaseAlertOnGitHubTests.cs
@@ -25,7 +25,7 @@ namespace CommandDotNet.Tests.CommandDotNet.NewerReleasesAlerts
             var version = "1.0.0";
 
             new AppRunner<App>()
-                .Configure(c => c.Services.AddOrUpdate(new VersionInfo("blah", version)))
+                .Configure(c => c.Services.AddOrUpdate(new AppInfo("blah", version)))
                 .UseNewerReleaseAlertOnGitHub(organizationName, repositoryName,
                     overrideHttpRequestCallback: (client, uri) => Task.FromResult(BuildGitHubApiResponse("1.0.1")))
                 .VerifyScenario(_testOutputHelper, new Scenario
@@ -50,7 +50,7 @@ namespace CommandDotNet.Tests.CommandDotNet.NewerReleasesAlerts
             var version = "1.0.1";
 
             new AppRunner<App>()
-                .Configure(c => c.Services.AddOrUpdate(new VersionInfo("blah", version)))
+                .Configure(c => c.Services.AddOrUpdate(new AppInfo("blah", version)))
                 .UseNewerReleaseAlertOnGitHub(organizationName, repositoryName, 
                     overrideHttpRequestCallback: (client, uri) => Task.FromResult(BuildGitHubApiResponse("1.0.0")))
                 .VerifyScenario(_testOutputHelper, new Scenario
@@ -75,7 +75,7 @@ namespace CommandDotNet.Tests.CommandDotNet.NewerReleasesAlerts
             var version = "1.0.0";
 
             new AppRunner<App>()
-                .Configure(c => c.Services.AddOrUpdate(new VersionInfo("blah", version)))
+                .Configure(c => c.Services.AddOrUpdate(new AppInfo("blah", version)))
                 .UseNewerReleaseAlertOnGitHub(organizationName, repositoryName,
                     overrideHttpRequestCallback: (client, uri) => Task.FromResult(BuildGitHubApiResponse("1.0.1")),
                     skipCommand:command => true)

--- a/CommandDotNet/Builders/AppInfo.cs
+++ b/CommandDotNet/Builders/AppInfo.cs
@@ -103,7 +103,8 @@ namespace CommandDotNet.Builders
 
             if (mainModuleFileName != null)
             {
-                if (!(appInfo.IsRunViaDotNetExe = mainModuleFileName.Equals("dotnet.exe")))
+                // osx uses 'dotnet' instead of 'dotnet.exe'
+                if (!(appInfo.IsRunViaDotNetExe = mainModuleFileName.Equals("dotnet.exe") || mainModuleFileName.Equals("dotnet")))
                 {
                     var entryAssemblyFileNameWithoutExt = Path.GetFileNameWithoutExtension(entryAssemblyFileName);
                     appInfo.IsSelfContainedExe = appInfo._isExe = mainModuleFileName.EndsWith($"{entryAssemblyFileNameWithoutExt}.exe");

--- a/CommandDotNet/Builders/AppInfo.cs
+++ b/CommandDotNet/Builders/AppInfo.cs
@@ -1,0 +1,136 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using CommandDotNet.Logging;
+
+namespace CommandDotNet.Builders
+{
+    /// <summary>
+    /// The version and file information for the application.<br/>
+    /// Uses <see cref="Assembly.GetEntryAssembly"/> and determines if app is run via
+    /// dotnet console app or as an exe or as a self-contained single executable<br/>
+    /// For unit tests, use `AppRunner.Configure(c =&gt; c.Services.Set(new AppInfo(...)))`
+    /// to set to specific version
+    /// </summary>
+    public class AppInfo
+    {
+        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
+
+        private static AppInfo s_appInfo;
+
+        internal static AppInfo Instance => s_appInfo ?? (s_appInfo = BuildAppInfo());
+
+        private string _version;
+
+        /// <summary>The entry assembly. Could be an exe or dll.</summary>
+        private Assembly _entryAssembly;
+
+        /// <summary>
+        /// The exe hosting the assembly.
+        /// Could be dotnet.exe, single executable containing zipped dll or the entry assembly.
+        /// </summary>
+        private ProcessModule _mainModule;
+
+        /// <summary>True the app is an executable, whether as a self-contained single executable or otherwise</summary>
+        private bool _isExe;
+
+        /// <summary>True if published as a self-contained single executable</summary>
+        public bool IsSelfContainedExe { get; set; }
+
+        /// <summary>True if run using the dotnet.exe</summary>
+        public bool IsRunViaDotNetExe { get; set; }
+
+        /// <summary>The file name used to execute the app</summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>The file name used to execute the app</summary>
+        public string FileName { get; private set; }
+
+        public string Version => _version ?? (_version = GetVersion(_entryAssembly));
+
+        private AppInfo()
+        {
+        }
+
+        public AppInfo(string fileName, string version)
+        {
+            FileName = fileName;
+            _version = version;
+        }
+        public static AppInfo GetAppInfo(CommandContext commandContext)
+        {
+            var svcs = commandContext.AppConfig.Services;
+            var appInfo = svcs.Get<AppInfo>();
+            if (appInfo == null)
+            {
+                svcs.AddOrUpdate(appInfo = AppInfo.Instance);
+            }
+            return appInfo;
+        }
+
+        private static AppInfo BuildAppInfo()
+        {
+            var appInfo = new AppInfo
+            {
+                _entryAssembly = Assembly.GetEntryAssembly()
+            };
+            if (appInfo._entryAssembly == null)
+            {
+                throw new AppRunnerException(
+                    "Unable to determine version because Assembly.GetEntryAssembly() is null. " +
+                    "This is a known issue when running unit tests in .net framework. https://tinyurl.com/y6rnjqsg" +
+                    "Set the version info in AppRunner.Configure(c => c.Services.Set(new AppInfo(...))) " +
+                    "to create a specific info for tests");
+            }
+
+            // this could be dotnet.exe or {app_name}.exe if published as single executable
+            appInfo._mainModule = Process.GetCurrentProcess().MainModule;
+            var mainModuleFilePath = appInfo._mainModule?.FileName;
+            var entryAssemblyFilePath = appInfo._entryAssembly?.Location;
+            
+            Log.Debug($"{nameof(mainModuleFilePath)}: {mainModuleFilePath}");
+            Log.Debug($"{nameof(entryAssemblyFilePath)}: {entryAssemblyFilePath}");
+
+            var mainModuleFileName = Path.GetFileName(mainModuleFilePath);
+            var entryAssemblyFileName = Path.GetFileName(entryAssemblyFilePath);
+
+            // this logic isn't not covered by unit tests.
+            // changing this logic requires manual testing of
+            // - .dll files run in dotnet
+            // - .exe console apps
+            // - .dll published as self-contained .exe files.
+            // - windows, linux & mac
+
+            if (mainModuleFileName != null)
+            {
+                if (!(appInfo.IsRunViaDotNetExe = mainModuleFileName.Equals("dotnet.exe")))
+                {
+                    var entryAssemblyFileNameWithoutExt = Path.GetFileNameWithoutExtension(entryAssemblyFileName);
+                    appInfo.IsSelfContainedExe = appInfo._isExe = mainModuleFileName.EndsWith($"{entryAssemblyFileNameWithoutExt}.exe");
+                }
+            }
+
+            appInfo._isExe = appInfo._isExe || entryAssemblyFileName.EndsWith("exe");
+
+            appInfo.FilePath = appInfo.IsSelfContainedExe
+                ? mainModuleFilePath
+                : entryAssemblyFilePath;
+
+            appInfo.FileName = Path.GetFileName(appInfo.FilePath);
+
+            Log.Debug($"  {nameof(FileName)}={appInfo.FileName} " +
+                      $"{nameof(IsRunViaDotNetExe)}={appInfo.IsRunViaDotNetExe} " +
+                      $"{nameof(IsSelfContainedExe)}={appInfo.IsSelfContainedExe} " +
+                      $"{nameof(FilePath)}={appInfo.FilePath}");
+
+            return appInfo;
+        }
+
+        internal static string GetVersion(Assembly hostAssembly)
+        {
+            var filename = Path.GetFileName(hostAssembly.Location);
+            var fvi = FileVersionInfo.GetVersionInfo(hostAssembly.Location);
+            return fvi.ProductVersion;
+        }
+    }
+}

--- a/CommandDotNet/Builders/VersionMiddleware.cs
+++ b/CommandDotNet/Builders/VersionMiddleware.cs
@@ -54,10 +54,10 @@ namespace CommandDotNet.Builders
 
         private static void Print(CommandContext commandContext, IConsole console)
         {
-            var versionInfo = VersionInfo.GetVersionInfo(commandContext);
+            var appInfo = AppInfo.GetAppInfo(commandContext);
 
-            console.Out.WriteLine(versionInfo.Filename);
-            console.Out.WriteLine(versionInfo.Version);
+            console.Out.WriteLine(appInfo.FileName);
+            console.Out.WriteLine(appInfo.Version);
         }
     }
 }

--- a/CommandDotNet/Help/HelpBuilderExtensions.cs
+++ b/CommandDotNet/Help/HelpBuilderExtensions.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
+using CommandDotNet.Builders;
 using CommandDotNet.Extensions;
-using CommandDotNet.Logging;
 
 namespace CommandDotNet.Help
 {
     internal static class HelpBuilderExtensions
     {
-        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
-
         internal static string GetAppName(this Command command, AppHelpSettings appHelpSettings)
         {
             if (!appHelpSettings.UsageAppName.IsNullOrEmpty())
@@ -21,70 +16,32 @@ namespace CommandDotNet.Help
             switch (appHelpSettings.UsageAppNameStyle)
             {
                 case UsageAppNameStyle.Adaptive:
-                    return GetAppNameAdaptive();
+                    var appInfo = AppInfo.Instance;
+                    return appInfo.IsRunViaDotNetExe
+                        ? $"dotnet {appInfo.FileName}"
+                        : appInfo.FileName;
                 case UsageAppNameStyle.DotNet:
-                    return $"dotnet {GetAppFileName()}";
+                    return $"dotnet {AppInfo.Instance.FileName}";
                 case UsageAppNameStyle.GlobalTool:
-                    var rootAppName = GetRootAppName(command);
+                    var rootAppName = command.GetRootCommand()
+                        .CustomAttributes?
+                        .GetCustomAttribute<CommandAttribute>()?
+                        .Name;
                     if (rootAppName == null)
                     {
                         throw new AppRunnerException(
                             $"Invalid configuration: {nameof(CommandAttribute)}.{nameof(CommandAttribute.Name)} " +
                             $"is required for the root command when {nameof(UsageAppNameStyle)}.{nameof(UsageAppNameStyle.GlobalTool)} " +
-                            "is specified.");
+                            $"is specified.{Environment.NewLine}" +
+                            $"Use {nameof(AppSettings)}.{nameof(AppSettings.Help)}.{nameof(AppHelpSettings.UsageAppName)} " +
+                            $"instead of {nameof(UsageAppNameStyle)}.{nameof(UsageAppNameStyle.GlobalTool)}.");
                     }
                     return rootAppName;
                 case UsageAppNameStyle.Executable:
-                    return GetAppFileName();
+                    return AppInfo.Instance.FileName;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(UsageAppNameStyle), $"unknown style: {appHelpSettings.UsageAppNameStyle}");
             }
-        }
-
-        private static string GetAppNameAdaptive()
-        {
-            string fileName = GetAppFileName();
-            if (fileName != null)
-            {
-                // If the file is an .exe, it's more likely a .Net Framework file
-                // and will not be executed via the dotnet tool.
-                return fileName.EndsWith(".exe") ? fileName : $"dotnet {fileName}";
-            }
-
-            // https://github.com/bilal-fazlani/commanddotnet/issues/65
-            // in some cases, entry assembly won't exist.  generally only an issue for tests.
-            return "...";
-        }
-
-        private static string GetRootAppName(Command command)
-        {
-            return command.GetRootCommand().CustomAttributes?.GetCustomAttribute<CommandAttribute>()?.Name;
-        }
-
-        private static string GetAppFileName()
-        {
-            var mainModuleFilePath = Process.GetCurrentProcess().MainModule?.FileName;
-            var hostAssemblyFilePath = Assembly.GetEntryAssembly()?.Location;
-
-            Log.Debug($"{nameof(mainModuleFilePath)}: {mainModuleFilePath}");
-            Log.Debug($"{nameof(hostAssemblyFilePath)}: {hostAssemblyFilePath}");
-            
-            var mainModuleFileName = Path.GetFileName(mainModuleFilePath);
-            var assemblyFileName = Path.GetFileName(hostAssemblyFilePath);
-
-            if (mainModuleFileName == null || mainModuleFileName.Equals("dotnet.exe") || assemblyFileName.EndsWith("exe"))
-            {
-                return assemblyFileName;
-            }
-
-            if (hostAssemblyFilePath.EndsWith(".dll") &&
-                mainModuleFilePath.EndsWith($"{Path.GetFileNameWithoutExtension(hostAssemblyFilePath)}.exe"))
-            {
-                // app is published as a single file
-                return mainModuleFileName;
-            }
-
-            return assemblyFileName;
         }
     }
 }


### PR DESCRIPTION
AppInfo will return the correct file name and logic is now
in one place to determine if dotnet, self-contained.exe or
regular .exe