### PR TITLE
#183 - ShortName does not remove LongName setting

### DIFF
--- a/CommandDotNet.Tests/CommandDotNet.CommandLogger/CommandLoggerTests.cs
+++ b/CommandDotNet.Tests/CommandDotNet.CommandLogger/CommandLoggerTests.cs
@@ -165,6 +165,7 @@ AppConfig:
       UsageAppName:
       UsageAppNameStyle: Adaptive
     IgnoreUnexpectedOperands: False
+    LongNameAlwaysDefaultsToSymbolName: False
   DependencyResolver:
   HelpProvider: CommandDotNet.Help.HelpTextProvider
   TokenTransformations:

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_Name_Legacy_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_Name_Legacy_Tests.cs
@@ -7,11 +7,11 @@ using Xunit.Abstractions;
 
 namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
-    public class Options_Name_Tests
+    public class Options_Name_Legacy_Tests
     {
         private readonly Option[] _options;
 
-        public Options_Name_Tests(ITestOutputHelper testOutputHelper)
+        public Options_Name_Legacy_Tests(ITestOutputHelper testOutputHelper)
         {
             Command cmd = null;
             new AppRunner<App>()

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Options_Name_New_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Options_Name_New_Tests.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using CommandDotNet.Execution;
+using CommandDotNet.TestTools;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Arguments
+{
+    public class Options_Name_New_Tests
+    {
+        private readonly Option[] _options;
+
+        public Options_Name_New_Tests(ITestOutputHelper testOutputHelper)
+        {
+            Command cmd = null;
+
+            new AppRunner<App>(new AppSettings { LongNameAlwaysDefaultsToSymbolName = true })
+                .CaptureState(ctx => cmd = ctx.ParseResult.TargetCommand, MiddlewareStages.PostParseInputPreBindValues, exitAfterCapture: true)
+                .RunInMem("Do", testOutputHelper);
+            _options = cmd.Options.ToArray();
+        }
+
+        [InlineData(0, "defaultName", null, "defaultName")]
+        [InlineData(1, "longName1", null, "longName1")]
+        [InlineData(2, "shortNameOverride", 'a', "shortNameOverride")]
+        [InlineData(3, "longName2", 'b', "longName2")]
+        [InlineData(4, null, 'c', "c")]
+        [Theory]
+        public void NameShouldBe(int i, string longName, char? shortName, string name)
+        {
+            var option = _options[i];
+            option.LongName.Should().Be(longName);
+            option.ShortName.Should().Be(shortName);
+            option.Name.Should().Be(name);
+        }
+
+        class App
+        {
+            public int Do(
+                [Option] string defaultName,
+                [Option(LongName = "longName1")] string longNameOverride,
+                [Option(ShortName = "a")] string shortNameOverride,
+                [Option(ShortName = "b", LongName = "longName2")] string shortAndLongNameOverride,
+                [Option(ShortName = "c", LongName = null)] string longNameNull,
+                [Option(ShortName = "d", LongName = "")] string longNameEmpty)
+            {
+                return 1;
+            }
+        }
+    }
+}

--- a/CommandDotNet/AppSettings.cs
+++ b/CommandDotNet/AppSettings.cs
@@ -27,6 +27,14 @@ namespace CommandDotNet
         }
 
         /// <summary>
+        /// Note: This setting will become the the default behavior in the next major release.<br/>
+        ///       Set to true now to reduce future upgrade churn.<br/>
+        /// When true, setting <see cref="OptionAttribute.ShortName"/> does not nullify the LongName defaulted from the parameter or property.<br/>
+        /// Setting <see cref="OptionAttribute.LongName"/> to null will ensure the option has only a short name.
+        /// </summary>
+        public bool LongNameAlwaysDefaultsToSymbolName { get; set; }
+
+        /// <summary>
         /// When false, unexpected arguments will result in a parse failure with help message.<br/>
         /// When true, unexpected arguments will be ignored
         /// </summary>

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -106,7 +106,11 @@ namespace CommandDotNet.ClassModeling.Definitions
                 var assignOnlyToExecutableSubcommands = optionAttr?.AssignToExecutableSubcommands ?? false;
                 isInterceptorOption = isInterceptorOption && !assignOnlyToExecutableSubcommands;
 
-                var longName = optionAttr?.ShortName != null 
+                var ignoreDefaultLongName = appConfig.AppSettings.LongNameAlwaysDefaultsToSymbolName
+                    ? (optionAttr?.IgnoreDefaultLongName ?? false)
+                    : optionAttr?.ShortName != null;
+
+                var longName = ignoreDefaultLongName 
                     ? optionAttr?.LongName 
                     : (optionAttr?.LongName ?? argumentDef.Name);
                 return new Option(

--- a/CommandDotNet/OptionAttribute.cs
+++ b/CommandDotNet/OptionAttribute.cs
@@ -5,11 +5,33 @@ namespace CommandDotNet
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
     public class OptionAttribute : Attribute, INameAndDescription
     {
-        /// <summary>Must be a single character</summary>
+        /// <summary>
+        /// The single character short name for the option.<br/>
+        /// This will change the default behavior of LongName (setting the default to Null) unless
+        /// <see cref="AppSettings.LongNameAlwaysDefaultsToSymbolName"/> is true.<br/>
+        /// When the setting is true, set <see cref="LongName"/> to null to remove
+        /// the default long name.
+        /// </summary>
         public string ShortName { get; set; }
 
-        public string LongName { get; set; }
+        private string _longName;
 
+        /// <summary>
+        /// The long name for the option. Defaults to the parameter or property name.<br/>
+        /// Set to null to prevent the option from having a long name.
+        /// </summary>
+        public string LongName
+        {
+            get => _longName;
+            set
+            {
+                IgnoreDefaultLongName = value.IsNullOrEmpty();
+                _longName = value;
+            }
+        }
+
+        public bool IgnoreDefaultLongName { get; private set; }
+        
         string INameAndDescription.Name => LongName;
 
         /// <summary>

--- a/docs/DefiningCommands/arguments.md
+++ b/docs/DefiningCommands/arguments.md
@@ -18,21 +18,29 @@ Use the `[Operand]` and `[Option]` attributes to explicity denote which argument
 
 The operand attribute has the following properties:
 
-* __Name__: Used in help documentation only. Defaults to the method name.
+* __Name__: Used in help documentation only. Defaults to the parameter or property name.
 * __Description__: Used in help documentation.
 
 ## Option Attribute
 
 The option attribute has the following properties:
 
-* __ShortName__: Using in help documentation and on the command line. Defaults to null.
-* __LongName__: Used in help documentation and on the command line. Defaults to the method name.
+* __LongName__: Used in help documentation and on the command line. Defaults to the parameter or property name.
+* __ShortName__: Used in help documentation and on the command line. Defaults to null.
 * __Description__: Used in help documentation.
 * __BooleanMode__: When the option is a `bool`, this determines if the presence of the option 
   indicates `true` (_Implicit_) or if the user must specify `true` or `false` (_Explicit_). 
     * The default is _Implicit_ and can be changed with `#!c# AppSettings.BooleanMode = BooleanMode.Explicit`
     * _Implicit_ boolean options are also called __Flags__
 * __AssignToExecutableSubcommands__: only valid when used in [Interceptor](../Extensibility/interceptors.md) methods.
+
+### ShortName and LongName interactions
+When ShortName is set, LongName will no longer default to the parameter or property name. If an option should have both a short and long name, then both attributes need to be set. This can result in duplicating the name that was already used to define the option.
+
+In the next major release, this behavior will change so that LongName will always default to the parameter or property name. 
+An option can be configured to have only a short name by setting `LongName = null`.
+
+In the meantime, this behavior can be achieved by setting `AppSettings.LongNameAlwaysDefaultsToSymbolName = true`
 
 ## Example
 


### PR DESCRIPTION
Add setting so ShortName can be set without losing the
default long name from the property or parameter.

This will become the default behavior in the next major
version