### PR TITLE
fix commad logger logging without [cmdlog] specified

### DIFF
--- a/CommandDotNet.Tests/CommandDotNet.CommandLogger/CommandLoggerTests.cs
+++ b/CommandDotNet.Tests/CommandDotNet.CommandLogger/CommandLoggerTests.cs
@@ -24,13 +24,13 @@ namespace CommandDotNet.Tests.CommandDotNet.CommandLogger
                 .UseCommandLogger(excludeSystemInfo: true)
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
-                    WhenArgs = "--password super-secret Do lala",
+                    WhenArgs = "[cmdlog] --password super-secret Do lala",
                     Then =
                     {
                         Result = $@"
 ***************************************
 Original input:
-  --password ***** Do lala
+  [cmdlog] --password ***** Do lala
 
 command: Do
 
@@ -64,13 +64,13 @@ options:
                 .UseCommandLogger()
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
-                    WhenArgs = "Do",
+                    WhenArgs = "[cmdlog] Do",
                     Then =
                     {
                         Result = $@"
 ***************************************
 Original input:
-  Do
+  [cmdlog] Do
 
 command: Do
 
@@ -110,13 +110,13 @@ Username      = {Environment.UserDomainName}\{Environment.UserName}
                 .UseCommandLogger(excludeSystemInfo: true, includeAppConfig:true)
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
-                    WhenArgs = "Do",
+                    WhenArgs = "[cmdlog] Do",
                     Then =
                     {
                         Result = $@"
 ***************************************
 Original input:
-  Do
+  [cmdlog] Do
 
 command: Do
 
@@ -198,13 +198,13 @@ AppConfig:
                 .UseCommandLogger(excludeSystemInfo: true, additionalInfoCallback: ctx => null)
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
-                    WhenArgs = "Do",
+                    WhenArgs = "[cmdlog] Do",
                     Then =
                     {
                         Result = $@"
 ***************************************
 Original input:
-  Do
+  [cmdlog] Do
 
 command: Do
 
@@ -243,13 +243,13 @@ options:
                 })
                 .VerifyScenario(_testOutputHelper, new Scenario
                 {
-                    WhenArgs = "Do",
+                    WhenArgs = "[cmdlog] Do",
                     Then =
                     {
                         Result = $@"
 ***************************************
 Original input:
-  Do
+  [cmdlog] Do
 
 command: Do
 
@@ -339,6 +339,30 @@ options:
     default:
 ***************************************
 ");
+        }
+
+        [Fact]
+        public void DefaultBehavior_DoesOutput_With_CmdLogDirective()
+        {
+            new AppRunner<App>()
+                .UseCommandLogger()
+                .VerifyScenario(_testOutputHelper, new Scenario
+                {
+                    WhenArgs = "[cmdlog] Do",
+                    Then = { ResultsContainsTexts = { "Original input:" } }
+                });
+        }
+
+        [Fact]
+        public void DefaultBehavior_DoesNotOutput_Without_CmdLogDirective()
+        {
+            new AppRunner<App>()
+                .UseCommandLogger()
+                .VerifyScenario(_testOutputHelper, new Scenario
+                {
+                    WhenArgs = "Do",
+                    Then = {Result = ""}
+                });
         }
 
         public class App

--- a/CommandDotNet/Execution/CommandLoggerMiddleware.cs
+++ b/CommandDotNet/Execution/CommandLoggerMiddleware.cs
@@ -42,7 +42,7 @@ namespace CommandDotNet.Execution
                 bool includeAppConfig,
                 Func<CommandContext, IEnumerable<(string, string)>> additionalHeadersCallback)
             {
-                WriterFactory = writerFactory ?? (ctx => ctx.Console.Out.WriteLine);
+                WriterFactory = writerFactory;
                 IncludeSystemInfo = includeSystemInfo;
                 IncludeAppConfig = includeAppConfig;
                 AdditionalHeadersCallback = additionalHeadersCallback;


### PR DESCRIPTION
the default behavior is only to output when the cmdlog
directive is specified.