### PR TITLE
spike: modify usage - use two lines when subcommands...

### DIFF
--- a/CommandDotNet/StringExtensions.cs
+++ b/CommandDotNet/StringExtensions.cs
@@ -23,5 +23,7 @@ namespace CommandDotNet
             text.Split(new[] { "\r\n", "\r", "\n" }, stringSplitOptions);
 
         internal static string Repeat(this string value, int count) => Enumerable.Repeat(value, count).ToCsv(null);
+
+        internal static string TrimNewLines(this string value) => value?.Trim('\n', '\r');
     }
 }


### PR DESCRIPTION
and the target command is executable

with results between

Usage:
  {AppName} {CommandPath}
  {AppName} {CommandPath} [commands]

and

Usage:
  {AppName} {CommandPath} [options] [arguments]
  {AppName} {CommandPath} [options] [commands]

When the command is not executable, results will be like

Usage: {AppName} {CommandPath} [options] [commands]

When no subcommands, results will be like

Usage: {AppName} {CommandPath} [options] [arguments]