### PR TITLE
support `--` as end-of-options indicator

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/Arguments/ArgumentSeparatorTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/ArgumentSeparatorTests.cs
@@ -1,0 +1,229 @@
+using CommandDotNet.Rendering;
+using CommandDotNet.TestTools.Scenarios;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Arguments
+{
+    public class ArgumentSeparatorTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        private readonly AppSettings _appSettingsEndOfOptions = new AppSettings
+        {
+            DefaultArgumentSeparatorStrategy = ArgumentSeparatorStrategy.EndOfOptions
+        };
+
+        private readonly AppSettings _appSettingsPassThru = new AppSettings
+        {
+            DefaultArgumentSeparatorStrategy = ArgumentSeparatorStrategy.PassThru
+        };
+
+        public ArgumentSeparatorTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Given_PassThru_When_OperandValueWithDash_FailsWithUnrecognizedOption()
+        {
+            new AppRunner<Math>(_appSettingsPassThru)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -1 -3",
+                    Then =
+                    {
+                        ExitCode = 1,
+                        ResultsContainsTexts = { "Unrecognized option '-1'" }
+                    }
+                });
+        }
+
+        [Fact]
+        public void Given_EndOfOptions_ByAppSetting_When_OperandValueWithDash_FailsWithUnrecognizedOption()
+        {
+            new AppRunner<Math>(_appSettingsEndOfOptions)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -1 -3",
+                    Then =
+                    {
+                        ExitCode = 1,
+                        ResultsContainsTexts = { "Unrecognized option '-1'" }
+                    }
+                });
+        }
+
+        [Fact]
+        public void Given_EndOfOptions_ByCommand_When_OperandValueWithDash_FailsWithUnrecognizedOption()
+        {
+            new AppRunner<Math>(_appSettingsPassThru)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add_EndOfOptions -1 -3",
+                    Then =
+                    {
+                        ExitCode = 1,
+                        ResultsContainsTexts = { "Unrecognized option '-1'" }
+                    }
+                });
+        }
+
+        [Fact]
+        public void Given_PassThru_ByAppSetting_When_Separator_OperandValueWithDash_OperandsAreIgnored()
+        {
+            var result = new AppRunner<Math>(_appSettingsPassThru)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -- -1 -3",
+                    Then = { Result = "0" }
+                });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3" });
+        }
+
+        [Fact]
+        public void Given_PassThru_ByCommand_When_Separator_OperandValueWithDash_OperandsAreIgnored()
+        {
+            var result = new AppRunner<Math>(_appSettingsEndOfOptions)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add_PassThru -- -1 -3",
+                    Then = { Result = "0" }
+                });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3" });
+        }
+
+        [Fact]
+        public void Given_EndOfOptions_ByAppSetting_When_Separator_OperandValueWithDash_OperandsAreParsed()
+        {
+            var result = new AppRunner<Math>(_appSettingsEndOfOptions)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -- -1 -3",
+                    Then = { Result = "-4" }
+                });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3" });
+        }
+
+        [Fact]
+        public void Given_EndOfOptions_ByCommand_When_Separator_OperandValueWithDash_OperandsAreParsed()
+        {
+            var result = new AppRunner<Math>(_appSettingsPassThru)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add_EndOfOptions -- -1 -3",
+                    Then = { Result = "-4" }
+                });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3" });
+        }
+
+        [Fact]
+        public void Given_EndOfOptions_ByAppSetting_And_IgnoreUnexpected_Enabled_When_Separator_OperandValueWithDash_OperandsAreParsed_And_ExtraArgsAreIgnoredAndCaptured()
+        {
+            var appSettings = _appSettingsEndOfOptions.Clone(s => s.IgnoreUnexpectedOperands = true);
+
+            var result = new AppRunner<Math>(appSettings)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -- -1 -3 -5 -7",
+                    Then = { Result = "-4" }
+                });
+
+            result.CommandContext.ParseResult.RemainingOperands
+                .Should().BeEquivalentTo(new[] { "-5", "-7" });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3", "-5", "-7" });
+        }
+
+        [Fact]
+        public void Given_EndOfOptions_ByCommand_And_IgnoreUnexpected_Enabled_When_Separator_OperandValueWithDash_OperandsAreParsed_And_ExtraArgsAreIgnoredAndCaptured()
+        {
+            var appSettings = _appSettingsPassThru.Clone(s => s.IgnoreUnexpectedOperands = true);
+
+            var result = new AppRunner<Math>(appSettings)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add_EndOfOptions -- -1 -3 -5 -7",
+                    Then = { Result = "-4" }
+                });
+
+            result.CommandContext.ParseResult.RemainingOperands
+                .Should().BeEquivalentTo(new[] { "-5", "-7" });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3", "-5", "-7" });
+        }
+
+        [Fact]
+        public void Help_Alternative2_IsValid()
+        {
+            // test examples in the help documentation
+
+            var appSettings = _appSettingsEndOfOptions.Clone(s => s.IgnoreUnexpectedOperands = true);
+
+            var result = new AppRunner<Math>(appSettings)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -- -1 -3 -- -5 -7",
+                    Then = { Result = "-4" }
+                });
+
+            result.CommandContext.ParseResult.RemainingOperands
+                .Should().BeEquivalentTo(new[] { "--", "-5", "-7" });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3", "--", "-5", "-7" });
+        }
+
+        [Fact]
+        public void Help_Alternative3_IsValid()
+        {
+            // test examples in the help documentation
+
+            var appSettings = _appSettingsEndOfOptions.Clone(s => s.IgnoreUnexpectedOperands = true);
+
+            var result = new AppRunner<Math>(appSettings)
+                .VerifyScenario(_output, new Scenario
+                {
+                    WhenArgs = "Add -- -1 -3 __ -5 -7",
+                    Then = { Result = "-4" }
+                });
+
+            result.CommandContext.ParseResult.RemainingOperands
+                .Should().BeEquivalentTo(new[] { "__", "-5", "-7" });
+
+            result.CommandContext.ParseResult.SeparatedArguments
+                .Should().BeEquivalentTo(new[] { "-1", "-3", "__", "-5", "-7" });
+        }
+
+        public class Math
+        {
+            public void Add(IConsole console, int x, int y)
+            {
+                console.WriteLine(x + y);
+            }
+
+            [Command(ArgumentSeparatorStrategy = ArgumentSeparatorStrategy.EndOfOptions)]
+            public void Add_EndOfOptions(IConsole console, int x, int y)
+            {
+                console.WriteLine(x + y);
+            }
+
+            [Command(ArgumentSeparatorStrategy = ArgumentSeparatorStrategy.PassThru)]
+            public void Add_PassThru(IConsole console, int x, int y)
+            {
+                console.WriteLine(x + y);
+            }
+        }
+    }
+}

--- a/CommandDotNet/AppSettings.cs
+++ b/CommandDotNet/AppSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using CommandDotNet.Extensions;
 using CommandDotNet.Help;
+using CommandDotNet.Parsing;
 using CommandDotNet.Tokens;
 using CommandDotNet.TypeDescriptors;
 
@@ -20,7 +21,7 @@ namespace CommandDotNet
             get => _booleanMode;
             set
             {
-                if(value == BooleanMode.Unknown)
+                if (value == BooleanMode.Unknown)
                     throw new AppRunnerException("BooleanMode can not be set to BooleanMode.Unknown explicitly");
                 _booleanMode = value;
             }
@@ -35,10 +36,16 @@ namespace CommandDotNet
         public bool LongNameAlwaysDefaultsToSymbolName { get; set; }
 
         /// <summary>
-        /// When false, unexpected arguments will result in a parse failure with help message.<br/>
-        /// When true, unexpected arguments will be ignored
+        /// When false, unexpected operands will generate a parse failure.<br/>
+        /// When true, unexpected arguments will be ignored and added to <see cref="ParseResult.RemainingOperands"/><br/>
         /// </summary>
         public bool IgnoreUnexpectedOperands { get; set; }
+
+        /// <summary>
+        /// The default <see cref="ArgumentSeparatorStrategy"/>.
+        /// This can be overridden for a <see cref="Command"/> using the <see cref="CommandAttribute"/>
+        /// </summary>
+        public ArgumentSeparatorStrategy DefaultArgumentSeparatorStrategy { get; set; } = ArgumentSeparatorStrategy.PassThru;
 
         /// <summary>
         /// When arguments are not decorated with [Operand] or [Option]

--- a/CommandDotNet/ArgumentSeparatorStrategy.cs
+++ b/CommandDotNet/ArgumentSeparatorStrategy.cs
@@ -1,0 +1,21 @@
+﻿using CommandDotNet.Parsing;
+
+namespace CommandDotNet
+{
+    /// <summary>
+    /// Determines whether arguments after the argument selector '--' are
+    /// parsed and collected or just collected.
+    /// </summary>
+    public enum ArgumentSeparatorStrategy
+    {
+        /// <summary>
+        /// Arguments after the argument separator '--' are added to <see cref="ParseResult.SeparatedArguments"/>
+        /// </summary>
+        PassThru,
+        /// <summary>
+        /// Arguments after the argument separator '--' are parsed as operands
+        /// and also added to <see cref="ParseResult.SeparatedArguments"/>
+        /// </summary>
+        EndOfOptions
+    }
+}

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -26,6 +26,8 @@ namespace CommandDotNet.ClassModeling.Definitions
                 command.Description = commandAttribute.Description;
                 command.Usage = commandAttribute.Usage;
                 command.ExtendedHelpText = commandAttribute.ExtendedHelpText;
+                command.IgnoreUnexpectedOperands = commandAttribute.IgnoreUnexpectedOperandsAsNullable;
+                command.ArgumentSeparatorStrategy = commandAttribute.ArgumentSeparatorStrategyAsNullable;
             }
 
             var commandBuilder = new CommandBuilder(command);

--- a/CommandDotNet/Command.cs
+++ b/CommandDotNet/Command.cs
@@ -77,6 +77,19 @@ namespace CommandDotNet
         /// <summary>The aliases defined for this command</summary>
         public IReadOnlyCollection<string> Aliases { get; }
 
+        /// <summary>
+        /// Overrides <see cref="AppSettings.IgnoreUnexpectedOperands"/><br/>
+        /// When false, unexpected operands will generate a parse failure.<br/>
+        /// When true, unexpected arguments will be ignored and added to <see cref="ParseResult.RemainingOperands"/><br/>
+        /// </summary>
+        public bool? IgnoreUnexpectedOperands { get; set; }
+
+        /// <summary>
+        /// The <see cref="ArgumentSeparatorStrategy"/>.
+        /// This can be set in the <see cref="CommandAttribute"/>
+        /// </summary>
+        public ArgumentSeparatorStrategy? ArgumentSeparatorStrategy { get; set; }
+
         /// <summary>The source that defined this command</summary>
         public string DefinitionSource { get; }
 

--- a/CommandDotNet/CommandAttribute.cs
+++ b/CommandDotNet/CommandAttribute.cs
@@ -12,6 +12,32 @@ namespace CommandDotNet
         public string Usage { get; set; }
 
         public string ExtendedHelpText { get; set; }
+
+        /// <summary>
+        /// Overrides <see cref="AppSettings.IgnoreUnexpectedOperands"/><br/>
+        /// When false, unexpected operands will generate a parse failure.<br/>
+        /// When true, unexpected arguments will be ignored and added to <see cref="ParseResult.RemainingOperands"/><br/>
+        /// </summary>
+        public bool IgnoreUnexpectedOperands
+        {
+            get => IgnoreUnexpectedOperandsAsNullable.GetValueOrDefault();
+            set => IgnoreUnexpectedOperandsAsNullable = value;
+        }
+
+        /// <summary>Returns a nullable version of <see cref="IgnoreUnexpectedOperands"/> that will be null if a value was not assigned</summary>
+        public bool? IgnoreUnexpectedOperandsAsNullable { get; private set; }
+
+        /// <summary>
+        /// The <see cref="ArgumentSeparatorStrategy"/> for the <see cref="Command"/>
+        /// </summary>
+        public ArgumentSeparatorStrategy ArgumentSeparatorStrategy
+        {
+            get => ArgumentSeparatorStrategyAsNullable.GetValueOrDefault();
+            set => ArgumentSeparatorStrategyAsNullable = value;
+        }
+
+        /// <summary>Returns a nullable version of <see cref="ArgumentSeparatorStrategy"/> that will be null if a value was not assigned</summary>
+        public ArgumentSeparatorStrategy? ArgumentSeparatorStrategyAsNullable { get; set; }
     }
 
     // keeping in this namespace for backwards compatibility with preview versions

--- a/CommandDotNet/CommandExtensions.cs
+++ b/CommandDotNet/CommandExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using CommandDotNet.Extensions;
 
@@ -95,5 +96,35 @@ namespace CommandDotNet
         /// <summary>Returns the input values for the argument with the given alias or null</summary>
         public static ICollection<InputValue> FindInputValues(this Command command, string alias) => 
             command.FindArgumentNode(alias) is IArgument argument ? argument.InputValues : null;
+
+        /// <summary>
+        /// Return the effective IgnoreUnexpectedOperands using the default
+        /// from <see cref="AppSettings.IgnoreUnexpectedOperands"/>
+        /// when <see cref="Command.IgnoreUnexpectedOperands"/> is not set.
+        /// </summary>
+        public static bool GetIgnoreUnexpectedOperands(this Command command, AppSettings appSettings)
+        {
+            if (appSettings == null)
+            {
+                throw new ArgumentNullException(nameof(appSettings));
+            }
+
+            return command?.IgnoreUnexpectedOperands ?? appSettings.IgnoreUnexpectedOperands;
+        }
+
+        /// <summary>
+        /// Return the effective <see cref="ArgumentSeparatorStrategy"/> using the default
+        /// from <see cref="AppSettings.DefaultArgumentSeparatorStrategy"/>
+        /// when <see cref="Command.ArgumentSeparatorStrategy"/> is not set.
+        /// </summary>
+        public static ArgumentSeparatorStrategy GetArgumentSeparatorStrategy(this Command command, AppSettings appSettings)
+        {
+            if (appSettings == null)
+            {
+                throw new ArgumentNullException(nameof(appSettings));
+            }
+
+            return command?.ArgumentSeparatorStrategy ?? appSettings.DefaultArgumentSeparatorStrategy;
+        }
     }
 }

--- a/CommandDotNet/Parsing/ParseResult.cs
+++ b/CommandDotNet/Parsing/ParseResult.cs
@@ -14,13 +14,13 @@ namespace CommandDotNet.Parsing
         /// If extra operands were provided and <see cref="AppSettings.IgnoreUnexpectedOperands"/> is true,
         /// The extra operands will be stored in the <see cref="RemainingOperands"/> collection.
         /// </summary>
-        public IReadOnlyCollection<Token> RemainingOperands { get; }
+        public IReadOnlyCollection<string> RemainingOperands { get; }
 
         /// <summary>
         /// All arguments provided after the argument separator "--" will be stored
         /// in the <see cref="SeparatedArguments"/> collection.
         /// </summary>
-        public IReadOnlyCollection<Token> SeparatedArguments { get; }
+        public IReadOnlyCollection<string> SeparatedArguments { get; }
 
         /// <summary>
         /// An exception encountered while parsing the commands.
@@ -40,16 +40,16 @@ namespace CommandDotNet.Parsing
             IReadOnlyCollection<Token> separatedArguments)
         {
             TargetCommand = command ?? throw new ArgumentNullException(nameof(command));
-            RemainingOperands = remainingOperands ?? new List<Token>();
-            SeparatedArguments = separatedArguments ?? new List<Token>();
+            RemainingOperands = remainingOperands?.ToArgsArray() ?? new string[0];
+            SeparatedArguments = separatedArguments?.ToArgsArray() ?? new string[0];
         }
 
         public ParseResult(Command command, Exception exception)
         {
             TargetCommand = command ?? throw new ArgumentNullException(nameof(command));
             ParseError = exception ?? throw new ArgumentNullException(nameof(exception));
-            RemainingOperands = new List<Token>();
-            SeparatedArguments = new List<Token>();
+            RemainingOperands = new string[0];
+            SeparatedArguments = new string[0];
         }
     }
 }

--- a/docs/DefiningCommands/argument-separator.md
+++ b/docs/DefiningCommands/argument-separator.md
@@ -1,0 +1,131 @@
+# Argument Separator
+
+The argument separater `--` has been adopted by various tools to serve two different strategies: [end-of-options indicator](#end-of-options-indicator) and [pass-thru arguments](#pass-thru-arguments).
+
+Use `AppSettings.DefaultArgumentSeparatorStrategy` to specify the which strategy to use.
+
+* v3 default is `PassThru` to prevent breaking behavior.
+* v4 default will be `EndOfOptions` so that by default users are enabled to enter any value as an operand.
+
+## End of Options Indicator
+
+[Posix guideline (#10)](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) 
+
+> The first -- argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '-' character.
+
+This was created to handle cases where operand values begin with `-` or `--` causing the parser to interpret them as options.
+
+Take the calculator example `add 1 2`. Let's try with negative numbers...
+
+```bash
+~
+$ calculator.exe add -1 -2
+
+Unrecognized option '-1'
+```
+
+And now with the separator
+
+```bash
+~
+$ calculator.exe add -- -1 -2
+
+3
+```
+
+All operands after the first ` -- ` will be stored in `CommandContext.ParseResult.SeparatedArguments` regardless of whether they were expected or not.
+
+## Unexpected Operands
+
+Unexpected operands occur when there are no longer operands to assign values to. This will result in a parsing exception unless `AppSettings.IgnoreUnexpectedOperands` is true, and then they will be stored in `CommandContext.ParseResult.RemainingOperands`.
+
+```bash
+~
+$ calculator.exe add 1 2 3
+
+Unrecognized command or argument '3'
+```
+
+## Pass-thru arguments
+
+While the Posix guideline specifies the `--` should be used as an end-of-options indicator, there's a common pattern
+to use `--` to denote arguments to be passed to a sub-process. 
+
+For example, [dotnet.exe](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run#options) has this discription for `--`:
+
+> Delimits arguments to dotnet run from arguments for the application being run. All arguments after this delimiter are passed to the application run.
+
+```bash
+dotnet run -- --input sunrise.CR2 --output sunrise.JPG
+```
+
+is equivalent to
+
+```bash
+imageconv.exe --input sunrise.CR2 --output sunrise.JPG
+```
+
+## How to support both?
+
+Explicit support for both concepts is complicated to provide generically because the framework cannot know
+
+* if a operands for a given command can be formatted like options or directives
+* if a command can expect pass-thru arguments 
+* if a user entered `--` to indicate end-of-options or pass-thru arguments
+
+Due to this complexity, we'll give you the data and let you determine the best approach based on the requirements of the command.
+
+For all cases, whether via AppSettings or CommandAttribute
+
+* IgnoreUnexpectedOperands = true
+* ArgumentSeparatorStrategy = ArgumentSeparatorStrategy.EndOfOptions
+
+### Approach #1:
+
+Using a *Random* command that takes a single number and then calls another program.
+
+When `Random 1 -- 2 3`
+
+* `CommandContext.ParseResult.RemainingOperands` contains `{"2", "3"}`
+* `CommandContext.ParseResult.SeparatedArguments` contains `{"2", "3"}`
+
+When `Random -- -1 2 3`
+
+* `CommandContext.ParseResult.RemainingOperands` contains `{"2", "3"}`
+* `CommandContext.ParseResult.SeparatedArguments` contains `{"-1", "2", "3"}`
+
+In this case, RemainingOperands always contains the pass-thru arguments.
+
+### Approach #2:
+
+Check for a second `--`
+
+When `Random 1 -- 2 3`
+
+* `CommandContext.ParseResult.RemainingOperands` contains `{"2", "3"}`
+* `CommandContext.ParseResult.SeparatedArguments` contains `{"2", "3"}`
+
+When `Random -- -1 -- 2 3`
+
+* `CommandContext.ParseResult.RemainingOperands` contains `{"--", "2", "3"}`
+* `CommandContext.ParseResult.SeparatedArguments` contains `{"-1", "--", "2", "3"}`
+
+### Approach #3:
+
+Override the help usage example and specify a different PassThru argument separator, eg. ` __ `
+
+When `Random 1 __ 2 3`
+
+* `CommandContext.ParseResult.RemainingOperands` contains `{"__", "2", "3"}`
+* `CommandContext.ParseResult.SeparatedArguments` contains `{ }`
+
+When `Random -- -1 __ 2 3`
+
+* `CommandContext.ParseResult.RemainingOperands` contains `{"__", "2", "3"}`
+* `CommandContext.ParseResult.SeparatedArguments` contains `{"-1", "__", "2", "3"}`
+
+## Argument Parsing Diagram
+
+This diagram shows how the parser handles options and operands based on settings.
+
+![Argument Parse Behavior](ArgumentParseBehavior.png)

--- a/docs/DefiningCommands/commands.md
+++ b/docs/DefiningCommands/commands.md
@@ -44,7 +44,7 @@ When the return type is `int` the value is used as the exit code.
 
 Every public method will be interpreted as a command and the command name will be the method name.
 
-Use the `[Command]` attribute to change the command name and enhance help output.
+Use the `[Command]` attribute to change the command name, enhance help output and provide parser hints.
 
 ```c#
 public class Calculator
@@ -60,15 +60,10 @@ public class Calculator
 }
 ```
 
-INPUT
-
 ```bash
-dotnet example.dll Add --help
-```
+~
+$ dotnet add.dll Add --help
 
-OUTPUT
-
-```bash
 dotnet example.dll sum -h
 sums two numbers
 
@@ -83,6 +78,8 @@ Arguments:
 more details and examples
 
 ```
+
+Use `IgnoreUnexpectedOperands` & `ArgumentSeparatorStrategy` to override argument parsing behavior for the command. See [Argument Separator](argument-separator.md) for more details.
 
 ## Default Method
 

--- a/docs/ReleaseNotes/CommandDotNet.md
+++ b/docs/ReleaseNotes/CommandDotNet.md
@@ -4,6 +4,20 @@
 
 ### Feature
 
+#### Argument Separator following [Posix Guideline](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) 10
+
+> The first -- argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '-' character.
+
+Before this release, all arguments following `--` were captured to `CommandContext.ParseResult.SeparatedArguments` and not made available for parsing. That prevented use of operands with values beginning with `-` or `--` or enclosed in square brackets when directives were not disabled.
+
+So `calculator.exe add -1 -2` was not possible.  With this release, `calculator.exe add -- -1 -2` is possible.  
+
+All arguments following `--` are still captured to `CommandContext.ParseResult.SeparatedArguments`, but now may include values for operands of the current command.  Compare w/ `CommandContext.ParseResult.RemainingOperands` to see if any were mapped into the command.
+
+See [Argument Separator](argument-separator.md) for more help.
+
+As part of this update, `CommandContext.ParseResult.SeparatedArguments` && `CommandContext.ParseResult.RemainingOperands` were changed from `IReadOnlyCollection<Token>` to `IReadOnlyCollection<string>`. 
+
 #### CommandLogger.Log
 
 Make CommandLogger a public class so commands, interceptors and middleware can run it directly.
@@ -11,6 +25,13 @@ Make CommandLogger a public class so commands, interceptors and middleware can r
 This makes the last pattern in the [Command Logger](command-logger.md) help possible, using an interceptor option to trigger the log.
 
 ### API
+
+#### CommandAttribute parse hints
+
+The followingw were added to the CommandAttribute to override AppSettings for the given command.
+
+* `IgnoreUnexpectedArguments` to override `AppSettings.IgnoreUnexpectedArguments`
+* `ArgumentSeparatorStrategy` to override `AppSettings.DefaultArgumentSeparatorStrategy`
 
 #### Console Write___ extension methods
 

--- a/docs/ReleaseNotes/roadmap.md
+++ b/docs/ReleaseNotes/roadmap.md
@@ -6,35 +6,40 @@ This is where you can track plans for the next major version of CommandDotNet th
 will result in breaking changes to behavior or the API.
 
 ### Features
-* default AppSettings.ExpandArgumentsInUsage to true.
-* default AppSettings.LongNameAlwaysDefaultsToSymbolName to true.
+* default `AppSettings.ExpandArgumentsInUsage` to true.
+* default `AppSettings.LongNameAlwaysDefaultsToSymbolName` to true.
+* default `AppSettings.DefaultArgumentSeparatorStrategy` to `EndOfOptions`.
 
 ### API
-* remove obsolete members
-  * AppSettings
-    * MethodArgumentMode - replaced by DefaultArgumentMode
-    * ThrowOnUnexpectedArgument - replaced by IgnoreUnexpectedArguments
-    * AllowArgumentSeparator - was never used for functionality, only to show `--` in help.
-    * HelpTextStyle - replaced by Help.TextStyle
-    * Help
-      * GlobalTool - replaced by UsageAppName
-  * VersionInfo - replaced by AppInfo
-  * ApplicationMetadataAttribute - replaced by CommandAttribute
-  * ArgumentAttribute - replaced by OperandAttribute
-  * ArgumentMode.Parameter - replaced by Operand
-  * InjectPropertyAttribute - v3 made ctor injection possible and that should be used.
-  * Command, Option, Operand ctor taking with `Command parent` parameter. Parent is now assigned by adding to a command.
-  * OptionAttribute
-    * Inherited - replaced by AssignToExecutableSubcommands
-  * Option
-    * DefaultValue - use Option.Default
-    * Inherited - replaced by AssignToExecutableSubcommands
-  * Operand
-    * DefaultValue - use Option.Default
-  * IArgument
-    * DefaultValue - use Option.Default
-  * appRunner.UseDefaultsFromConfig extension method that returns string, in favor of method with same name returning ArgumentDefault
-  * TokenCollection public ctor - Use Tokenizer.Tokenize extension method to generate tokens and TokenCollection.Transform to transform them. Ensures source tokens are correctly mapped.
-  * AnsiConsole - no longer supported. Use a package like ColorConsole or Pastel.
-  * CommandDotNet.Directives.Parse.ParseReporter - moved to CommandDotNet.Diagnostics.Parse.ParseReporter
-  * CommandDotNet.Directives.Debugger - moved to CommandDotNet.Diagnostics.Debugger
+
+#### moved
+  * `CommandDotNet.Directives.Parse.ParseReporter` - moved to `CommandDotNet.Diagnostics.Parse.ParseReporter`
+  * `CommandDotNet.Directives.Debugger` - moved to `CommandDotNet.Diagnostics.Debugger`
+
+#### removed or replaced
+
+  * `AppSettings`
+    * `MethodArgumentMode` - replaced by `DefaultArgumentMode`
+    * `ThrowOnUnexpectedArgument` - replaced by `IgnoreUnexpectedArguments`
+    * `AllowArgumentSeparator` - was never used for functionality, only to show `--` in help.
+    * `HelpTextStyle` - replaced by `Help.TextStyle`
+    * `Help`
+      * `GlobalTool` - replaced by `UsageAppName`
+  * `VersionInfo` - replaced by `AppInfo`
+  * `ApplicationMetadataAttribute` - replaced by `CommandAttribute`
+  * `ArgumentAttribute` - replaced by `OperandAttribute`
+  * `ArgumentMode.Parameter` - replaced by `Operand`
+  * `InjectPropertyAttribute` - v3 made ctor injection possible and that should be used.
+  * `Command`, `Option`, `Operand` ctor taking with `Command parent` parameter. `Parent` is now assigned by adding to a command.
+  * `OptionAttribute`
+    * `Inherited` - replaced by `AssignToExecutableSubcommands`
+  * `Option`
+    * `DefaultValue` - use `Option.Default`
+    * `Inherited` - replaced by `AssignToExecutableSubcommands`
+  * `Operand`
+    * `DefaultValue` - use `Option.Default`
+  * `IArgument`
+    * `DefaultValue` - use `Option.Default`
+  * `appRunner.UseDefaultsFromConfig` extension method that returns string, in favor of method with same name returning `ArgumentDefault`
+  * `TokenCollection` public ctor - Use `Tokenizer.Tokenize` extension method to generate tokens and `TokenCollection.Transform` to transform them. Ensures source tokens are correctly mapped.
+  * `AnsiConsole` - no longer supported. Use a package like ColorConsole or Pastel.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,8 @@ nav:
         - DefiningCommands/argument-models.md
         - DefiningCommands/argument-arity.md
         - DefiningCommands/option-or-operand.md
-        - DefiningCommands/passwords.md
+        - DefiningCommands/passwords.md 
+        - DefiningCommands/argument-separator.md
       - Extensibility:
         - Extensibility/help.md
         - Extensibility/directives.md


### PR DESCRIPTION
breaking:
- Change ParseResult RemainingOperands & SeparatedArguments
to IReadOnlyCollection<string>

other:
- Add ArgumentSeparatorStrategy {PassThru,EndOfOptions}
- Override arg parsing defaults via CommandAttribute with
  .IgnoreUnexpectedOperands & .ArgumentSeparatorStrategy
- update parser to honor ArgumentSeparatorStrategy