### PR TITLE
implement .UseErrorHandler w/ HandleErrorDelegate

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/ExceptionHandlingTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ExceptionHandlingTests.cs
@@ -3,11 +3,19 @@ using System.Threading.Tasks;
 using CommandDotNet.Diagnostics;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace CommandDotNet.Tests.FeatureTests
 {
     public class ExceptionHandlingTests
     {
+        private readonly ITestOutputHelper _output;
+
+        public ExceptionHandlingTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Theory]
         [InlineData(null, nameof(ExceptionApp.Default))]
         [InlineData(nameof(ExceptionApp.ThrowException))]
@@ -16,19 +24,69 @@ namespace CommandDotNet.Tests.FeatureTests
         public void CanThrowExceptions(string commandName, string exceptionMessage = null)
         {
             var args = commandName == null ? new string[0] : new[] { commandName };
-            AppRunner<ExceptionApp> appRunner = new AppRunner<ExceptionApp>();
-            Exception exception = Assert.Throws<Exception>(() => appRunner.Run(args));
-            exception.Message.Should().Be(exceptionMessage ?? commandName);
-            AssertHasCommandContext(exception);
+            var exception = Assert.Throws<Exception>(() => 
+                new AppRunner<ExceptionApp>().Run(args));
+            AssertException(exception, exceptionMessage ?? commandName, "ExceptionApp");
         }
 
         [Fact]
         public void CanThrowExceptionsFromConstructor()
         {
-            AppRunner<ExceptionConstructorApp> appRunner = new AppRunner<ExceptionConstructorApp>();
-            Exception exception = Assert.Throws<Exception>(() => appRunner.Run("Process"));
-            exception.Message.Should().Be("Constructor is broken");
+            var exception = Assert.Throws<Exception>(() => 
+                new AppRunner<ExceptionConstructorApp>().Run("Process"));
+            AssertException(exception, "Constructor is broken", "ExceptionConstructorApp");
+        }
+
+        [Theory]
+        [InlineData(null, nameof(ExceptionApp.Default))]
+        [InlineData(nameof(ExceptionApp.ThrowException))]
+        [InlineData(nameof(ExceptionApp.ThrowOneMoreException))]
+        [InlineData(nameof(ExceptionApp.ThrowExceptionAsync))]
+        public void CanHandleErrors(string commandName, string exceptionMessage = null)
+        {
+            var args = commandName == null ? new string[0] : new[] { commandName };
+            CommandContext context = null;
+            Exception exception = null;
+            var exitCode = new AppRunner<ExceptionApp>()
+                .UseErrorHandler((ctx, ex) =>
+                {
+                    context = ctx;
+                    exception = ex;
+                    return ExitCodes.Error.Result;
+                })
+                .Run(args);
+            exitCode.Should().Be(1);
+            AssertException(exception, exceptionMessage ?? commandName, "ExceptionApp");
+            context.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void CanHandleErrorsFromConstructor()
+        {
+            CommandContext context = null;
+            Exception exception = null;
+            var exitCode = new AppRunner<ExceptionConstructorApp>()
+                .UseErrorHandler((ctx, ex) =>
+                {
+                    context = ctx;
+                    exception = ex;
+                    return ExitCodes.Error.Result;
+                })
+                .Run("Process");
+
+            exitCode.Should().Be(1);
+            AssertException(exception, "Constructor is broken", "ExceptionConstructorApp");
+            context.Should().NotBeNull();
+        }
+
+        private void AssertException(Exception exception, string exceptionMessage, string appName)
+        {
+            exception.Should().NotBeNull();
+            exception.Message.Should().Be(exceptionMessage);
+            exception.StackTrace.Should()
+                .StartWith($"   at CommandDotNet.Tests.FeatureTests.ExceptionHandlingTests.{appName}.");
             AssertHasCommandContext(exception);
+            //_output.WriteLine(exception.StackTrace);
         }
 
         private static void AssertHasCommandContext(Exception exception)

--- a/CommandDotNet/Execution/MiddlewareSteps.cs
+++ b/CommandDotNet/Execution/MiddlewareSteps.cs
@@ -13,6 +13,7 @@ namespace CommandDotNet.Execution
         /// in the <see cref="MiddlewareStages.PreTokenize"/> stage.
         /// This will catch all exceptions in the pipeline stack.
         /// </summary>
+        [Obsolete("This step is no longer used for appRunner.UseErrorHandler.")]
         public static MiddlewareStep ErrorHandler { get; } = 
             new MiddlewareStep(MiddlewareStages.PreTokenize, DebugDirective.OrderWithinStage + 1000);
 

--- a/CommandDotNet/HandleErrorDelegate.cs
+++ b/CommandDotNet/HandleErrorDelegate.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace CommandDotNet
+{
+    public delegate int HandleErrorDelegate(CommandContext ctx, Exception exception);
+}

--- a/docs/ReleaseNotes/CommandDotNet.md
+++ b/docs/ReleaseNotes/CommandDotNet.md
@@ -1,8 +1,12 @@
 # CommandDotNet
 
+## 3.6.4
+
+Fixed appRunner.UserErrorHandler method with a better approach and new signatture. Updated [documentation](../Diagnostics/exceptions.md) with the approach.
+
 ## 3.6.3
 
-Remove .UserErrorHandler config method until the bug is fixed. Updated documentation with the approach.
+Remove appRunner.UserErrorHandler config method until the bug is fixed. Updated documentation with the approach.
 
 ## 3.6.2
 


### PR DESCRIPTION
this is a simpler implementation because it doesn't require
the consumer to inject in the pipeline. The delegate is
only called if an exception is thrown and it is called
outside of the async pipeline so it will have been
unwrapped.