### PR TITLE
move CancellationToken to CommandContext, enable sessions

### DIFF
--- a/CommandDotNet.Example/Examples.cs
+++ b/CommandDotNet.Example/Examples.cs
@@ -14,6 +14,27 @@ namespace CommandDotNet.Example
                            "Example: %UsageAppName% [debug] [parse] [log:info] cancel-me")]
     internal class Examples
     {
+        private static bool _inSession;
+
+        [DefaultMethod]
+        public void StartSession(
+            CommandContext context,
+            InteractiveSession interactiveSession, 
+            [Option(ShortName = "i")] bool interactive)
+        {
+            if (interactive && !_inSession)
+            {
+                context.Console.WriteLine("start session");
+                _inSession = true;
+                interactiveSession.Start();
+            }
+            else
+            {
+                context.Console.WriteLine($"no session {interactive} {_inSession}");
+                context.ShowHelpOnExit = true;
+            }
+        }
+
         [SubCommand]
         public Git Git { get; set; }
 

--- a/CommandDotNet.Example/InteractiveMiddleware.cs
+++ b/CommandDotNet.Example/InteractiveMiddleware.cs
@@ -1,0 +1,14 @@
+﻿namespace CommandDotNet.Example
+{
+    public static class InteractiveMiddleware
+    {
+        public static AppRunner UseInteractiveMode(this AppRunner appRunner, string appName)
+        {
+            return appRunner.Configure(c =>
+            {
+                // use the existing appRunner to reuse the configuration.
+                c.UseParameterResolver(ctx => new InteractiveSession(appRunner, appName, ctx));
+            });
+        }
+    }
+}

--- a/CommandDotNet.Example/InteractiveSession.cs
+++ b/CommandDotNet.Example/InteractiveSession.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Linq;
+using CommandDotNet.Builders;
+using CommandDotNet.Tokens;
+
+namespace CommandDotNet.Example
+{
+    public class InteractiveSession
+    {
+        private readonly AppRunner _appRunner;
+        private readonly string _appName;
+        private readonly CommandContext _context;
+
+        public InteractiveSession(AppRunner appRunner, string appName, CommandContext context)
+        {
+            _appRunner = appRunner;
+            _appName = appName;
+            _context = context;
+        }
+
+        public void Start()
+        {
+            var console = _context.Console;
+            var cancellationToken = _context.CancellationToken;
+
+            bool pressedCtrlC = false;
+            Console.CancelKeyPress += (sender, args) =>
+            {
+                pressedCtrlC = true;
+            };
+
+            PrintSessionInit();
+
+            bool pendingNewLine = false;
+            void Write(string value = null)
+            {
+                console.Write(value);
+                pendingNewLine = true;
+            }
+
+            void WriteLine(string value = null)
+            {
+                console.WriteLine(value);
+                pendingNewLine = false;
+            }
+
+            void EnsureNewLine()
+            {
+                if (pendingNewLine)
+                {
+                    WriteLine();
+                }
+            }
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                EnsureNewLine();
+                Write(">>>");
+                var input = console.In.ReadLine();
+                if (input is null || pressedCtrlC)
+                {
+                    pressedCtrlC = false;
+                    WriteLine();
+                    return;
+                }
+
+                var args = new CommandLineStringSplitter().Split(input).ToArray();
+                if (args.Length == 0)
+                {
+                    WriteLine();
+                    continue;
+                }
+                if (args.Length == 1)
+                {
+                    var singleArg = args[0];
+                    switch (singleArg)
+                    {
+                        case "exit":
+                        case "quit":
+                            return;
+                        case "help":
+                            PrintSessionHelp();
+                            continue;
+                    }
+                    if (singleArg == Environment.NewLine)
+                    {
+                        WriteLine();
+                        continue;
+                    }
+                }
+                EnsureNewLine();
+                _appRunner.Run(args);
+            }
+            EnsureNewLine();
+        }
+        private class DisposableAction : IDisposable
+        {
+            private readonly Action _action;
+
+            public DisposableAction(Action action)
+            {
+                _action = action ?? throw new ArgumentNullException(nameof(action));
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+
+        private void PrintSessionInit()
+        {
+            var appInfo = AppInfo.GetAppInfo(_context);
+            var console = _context.Console;
+            console.WriteLine($"{_appName} {appInfo.Version}");
+            console.WriteLine("Type 'help' to see interactive options");
+            console.WriteLine("Type '-h' or '--help' to options for commands");
+            console.WriteLine("Type 'exit', 'quit' or 'Ctrl+C' to exit.");
+        }
+
+        private void PrintSessionHelp()
+        {
+            var console = _context.Console;
+            console.WriteLine("Type '-h' or '--help' to options for commands");
+            console.WriteLine("Type 'exit', 'quit' or 'Ctrl+C' to exit.");
+        }
+    }
+}

--- a/CommandDotNet.Example/Program.cs
+++ b/CommandDotNet.Example/Program.cs
@@ -24,6 +24,7 @@ namespace CommandDotNet.Example
                 .UseLog2ConsoleDirective()
                 .UseNameCasing(Case.KebabCase)
                 .UseFluentValidation()
+                .UseInteractiveMode("Example")
                 .UseDefaultsFromAppSetting(appSettings, includeNamingConventions: true);
         }
     }

--- a/CommandDotNet.Tests/FeatureTests/CancellationTokenTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/CancellationTokenTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using CommandDotNet.Execution;
+using CommandDotNet.TestTools.Scenarios;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,54 +14,309 @@ namespace CommandDotNet.Tests.FeatureTests
         {
             Ambient.Output = output;
         }
-
+        
         [Fact]
-        public void MiddlewarePipelineShouldStopWhenCancellationIsRequested()
+        public void Console_CancelKeyPress_ShouldStop_MiddlewarePipeline()
         {
-            var tokenSource = new CancellationTokenSource();
             new AppRunner<App>()
+                .UseCancellationHandlers()
                 .Configure(c =>
                 {
-                    c.Services.AddOrUpdate(tokenSource);
-                    c.CancellationToken = tokenSource.Token;
-                    c.UseMiddleware(Cancel, MiddlewareStages.PostTokenizePreParseInput);
-                    c.UseMiddleware(Throw, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(MockCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
                 })
-                .RunInMem(new string[0])
-                .Console.AllText().Should().BeEmpty();
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { ExitCode = 0 }
+                });
         }
 
         [Fact]
-        public void EnsureNoFalsePositives()
+        public void Console_CancelKeyPress_Should_ApplyOnlyToNestedCommandContext()
         {
-            // this test ensures the previous test is not passing with a false positive
-            var tokenSource = new CancellationTokenSource();
-            var appRunner = new AppRunner<App>()
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Verify(new Scenario
+                {
+                    When = { Args = nameof(App.NestMockCtrlC) },
+                    Then =
+                    {
+                        ExitCode = 0,
+                        AssertContext = ctx => ctx.CancellationToken.IsCancellationRequested.Should().BeFalse()
+                    }
+                });
+        }
+
+        [Fact]
+        public void Console_CancelKeyPress_Disabled_During_IgnoreCtrlC()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
                 .Configure(c =>
                 {
-                    c.Services.AddOrUpdate(tokenSource);
-                    c.CancellationToken = tokenSource.Token;
-                    c.UseMiddleware(Throw, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(IgnoreCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(MockCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { ExitCode = 5 }
+                });
+        }
+
+        [Fact]
+        public void Console_CancelKeyPress_Enabled_After_IgnoreCtrlC()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(IgnoreCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(MockCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(UnignoreCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(MockCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then =
+                    {
+                        ExitCode = 0,
+                        Output = @"reached expected step"
+                    }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_ProcessExit_ShouldStop_MiddlewarePipeline()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(MockCurrentDomainProcessExit, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { ExitCode = 0 }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_ProcessExit_Ignores_IgnoreCtrlC()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(IgnoreCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(MockCurrentDomainProcessExit, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { ExitCode = 0 }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_ProcessExit_Should_CancelAllTokens()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Verify(new Scenario
+                {
+                    When = { Args = nameof(App.NestMockCurrentDomainProcessExit) },
+                    Then =
+                    {
+                        ExitCode = 0,
+                        AssertContext = ctx => ctx.CancellationToken.IsCancellationRequested.Should().BeTrue()
+                    }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_UnhandledException_NotTerminating_ShouldNotStop_MiddlewarePipeline()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(MockCurrentDomainUnhandledExceptionNonTerminating, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then =
+                    {
+                        ExitCode = 5,
+                        Output = @"reached expected step"
+                    }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_UnhandledException_Terminating_ShouldStop_MiddlewarePipeline()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(MockCurrentDomainUnhandledExceptionTerminating, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { ExitCode = 0 }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_UnhandledException_Terminating_Ignores_IgnoreCtrlC()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(IgnoreCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(MockCurrentDomainUnhandledExceptionTerminating, MiddlewareStages.PostTokenizePreParseInput);
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                })
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { ExitCode = 0 }
+                });
+        }
+
+        [Fact]
+        public void CurrentDomain_UnhandledException_Should_CancelAllTokens()
+        {
+            new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Verify(new Scenario
+                {
+                    When = { Args = nameof(App.NestMockCurrentDomainUnhandledExceptionTerminating) },
+                    Then =
+                    {
+                        ExitCode = 0,
+                        AssertContext = ctx => ctx.CancellationToken.IsCancellationRequested.Should().BeTrue()
+                    }
+                });
+        }
+
+        [Fact]
+        public void ShouldNotReachThisStep_ShouldFailTheTests()
+        {
+            // this test ensures the previous test is not passing with a false positive
+            var appRunner = new AppRunner<App>()
+                .UseCancellationHandlers()
+                .Configure(c =>
+                {
+                    c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
                 });
 
-            Assert.Throws<Exception>(() => appRunner.RunInMem(new string[0]))
+            Assert.Throws<Exception>(() => appRunner.RunInMem("Do"))
                 .Message.Should().Be("This middleware should not have been called");
         }
 
-        private Task<int> Cancel(CommandContext context, ExecutionDelegate next)
-        {
-            context.AppConfig.Services.Get<CancellationTokenSource>().Cancel();
-            return next(context);
-        }
-
-        private Task<int> Throw(CommandContext context, ExecutionDelegate next)
+        private static Task<int> ShouldNotReachThisStep(CommandContext context, ExecutionDelegate next)
         {
             throw new Exception("This middleware should not have been called");
         }
 
+        private static Task<int> ShouldReachThisStep(CommandContext context, ExecutionDelegate next)
+        {
+            context.Console.Write("reached expected step");
+            return next(context);
+        }
+
+        private static Task<int> MockCtrlC(CommandContext context, ExecutionDelegate next)
+        {
+            CancellationHandlers.TestAccess.Console_CancelKeyPress();
+            return next(context);
+        }
+
+        private static Task<int> IgnoreCtrlC(CommandContext context, ExecutionDelegate next)
+        {
+            context.Services.Add(CancellationHandlers.IgnoreCtrlC());
+            return next(context);
+        }
+
+        private static Task<int> UnignoreCtrlC(CommandContext context, ExecutionDelegate next)
+        {
+            context.Services.Get<IDisposable>().Dispose();
+            return next(context);
+        }
+
+        private static Task<int> MockCurrentDomainProcessExit(CommandContext context, ExecutionDelegate next)
+        {
+            CancellationHandlers.TestAccess.CurrentDomain_ProcessExit();
+            return next(context);
+        }
+
+        private static Task<int> MockCurrentDomainUnhandledExceptionTerminating(CommandContext context, ExecutionDelegate next)
+        {
+            CancellationHandlers.TestAccess.CurrentDomain_UnhandledException(true);
+            return next(context);
+        }
+
+        private static Task<int> MockCurrentDomainUnhandledExceptionNonTerminating(CommandContext context, ExecutionDelegate next)
+        {
+            CancellationHandlers.TestAccess.CurrentDomain_UnhandledException(false);
+            return next(context);
+        }
+
         public class App
         {
-            public void Do() { }
+            public int Do()
+            {
+                return 5;
+            }
+
+            public int NestMockCtrlC()
+            {
+                return new AppRunner<App>()
+                    .UseCancellationHandlers()
+                    .Configure(c =>
+                    {
+                        c.UseMiddleware(MockCtrlC, MiddlewareStages.PostTokenizePreParseInput);
+                        c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                    })
+                    .Run("Do");
+            }
+
+            public int NestMockCurrentDomainProcessExit()
+            {
+                return new AppRunner<App>()
+                    .UseCancellationHandlers()
+                    .Configure(c =>
+                    {
+                        c.UseMiddleware(MockCurrentDomainProcessExit, MiddlewareStages.PostTokenizePreParseInput);
+                        c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                    })
+                    .Run("Do");
+            }
+
+            public int NestMockCurrentDomainUnhandledExceptionTerminating()
+            {
+                return new AppRunner<App>()
+                    .UseCancellationHandlers()
+                    .Configure(c =>
+                    {
+                        c.UseMiddleware(MockCurrentDomainUnhandledExceptionTerminating, MiddlewareStages.PostTokenizePreParseInput);
+                        c.UseMiddleware(ShouldNotReachThisStep, MiddlewareStages.PostTokenizePreParseInput);
+                    })
+                    .Run("Do");
+            }
         }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/ParameterResolverTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParameterResolverTests.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using CommandDotNet.Execution;
 using CommandDotNet.Rendering;
 using CommandDotNet.Tests.Utils;
 using CommandDotNet.TestTools;
@@ -65,7 +66,6 @@ Options:
         public void ParameterServices_ArePassedToCommandAndInterceptorMethod()
         {
             new AppRunner<App>()
-                .Configure(c => c.CancellationToken = new CancellationTokenSource().Token)
                 .Verify(new Scenario
             {
                 When = {Args = "Do 7 --stringOption optValue"},

--- a/CommandDotNet/AppConfigBuilder.cs
+++ b/CommandDotNet/AppConfigBuilder.cs
@@ -25,7 +25,7 @@ namespace CommandDotNet
         {
             [typeof(CommandContext)] = ctx => ctx,
             [typeof(IConsole)] = ctx => ctx.Console,
-            [typeof(CancellationToken)] = ctx => ctx.AppConfig.CancellationToken
+            [typeof(CancellationToken)] = ctx => ctx.CancellationToken
         };
 
         public AppConfigBuilder(AppSettings appSettings)
@@ -59,12 +59,6 @@ namespace CommandDotNet
 
         /// <summary>Replace the internal system console with provided console</summary>
         public IConsole Console { get; set; } = new SystemConsole();
-
-        /// <summary>
-        /// This CancellationToken will be shared via the <see cref="CommandContext"/>
-        /// Set it to ensure all middleware can subscribe to a cancellation.
-        /// </summary>
-        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
 
         /// <summary>
         /// <see cref="OnRunCompleted"/> is triggered when after the pipeline has completed execution.
@@ -143,7 +137,7 @@ namespace CommandDotNet
             return new AppConfig(
                 AppSettings, Console, DependencyResolver, helpProvider, NameTransformation,
                 OnRunCompleted, TokenizationEvents, BuildEvents, Services, 
-                CancellationToken, _parameterResolversByType)
+                _parameterResolversByType)
             {
                 MiddlewarePipeline = _middlewareByStage
                     .SelectMany(kvp => 

--- a/CommandDotNet/AppRunnerConfigExtensions.cs
+++ b/CommandDotNet/AppRunnerConfigExtensions.cs
@@ -220,11 +220,6 @@ namespace CommandDotNet
                 additionalInfoCallback);
         }
 
-        /*
-        public static AppRunner UseErrorHandler(this AppRunner appRunner, ExecutionMiddleware handlerDelegate)
-            => appRunner.Configure(c => c.UseMiddleware(handlerDelegate, MiddlewareSteps.ErrorHandler));
-        */
-
         /// <summary>
         /// Returns the list of all possible types that could be instantiated to execute commands.<br/>
         /// Use get the list of types to register in your DI container.

--- a/CommandDotNet/CommandContext.cs
+++ b/CommandDotNet/CommandContext.cs
@@ -1,4 +1,5 @@
-﻿using CommandDotNet.Builders;
+﻿using System.Threading;
+using CommandDotNet.Builders;
 using CommandDotNet.Diagnostics.Parse;
 using CommandDotNet.Execution;
 using CommandDotNet.Extensions;
@@ -49,6 +50,13 @@ namespace CommandDotNet
 
         /// <summary>When true, help will be displayed as the app exits</summary>
         public bool ShowHelpOnExit { get; set; }
+
+        /// <summary>
+        /// The <see cref="CancellationToken"/>.<br/>
+        /// Be careful overwriting if it is not <see cref="CancellationToken"/>.None
+        /// in case other middleware already has a reference to it.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
 
         /// <summary>
         /// Services registered for the lifetime of the <see cref="CommandContext"/>.<br/>

--- a/CommandDotNet/Diagnostics/DebugDirective.cs
+++ b/CommandDotNet/Diagnostics/DebugDirective.cs
@@ -25,7 +25,7 @@ namespace CommandDotNet.Diagnostics
             if (commandContext.Tokens.HasDebugDirective())
             {
                 Debugger.Attach(
-                    commandContext.AppConfig.CancellationToken,
+                    commandContext.CancellationToken,
                     commandContext.Console,
                     commandContext.AppConfig.Services.Get<DebugDirectiveContext>().WaitForDebuggerToAttach);
             }

--- a/CommandDotNet/Execution/AppConfig.cs
+++ b/CommandDotNet/Execution/AppConfig.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using CommandDotNet.Builders;
 using CommandDotNet.Extensions;
 using CommandDotNet.Help;
@@ -25,12 +24,6 @@ namespace CommandDotNet.Execution
         public IConsole Console { get; }
 
         /// <summary>
-        /// The application <see cref="CancellationToken"/>.
-        /// Set in <see cref="AppRunner.Configure"/>
-        /// </summary>
-        public CancellationToken CancellationToken { get; }
-
-        /// <summary>
         /// Services registered for the lifetime of the application.<br/>
         /// Use to store configurations for use by middleware.<br/>
         /// Add services in <see cref="AppRunner.Configure"/>
@@ -50,7 +43,7 @@ namespace CommandDotNet.Execution
         /// </summary>
         public IHelpProvider HelpProvider { get; }
 
-        internal Action<OnRunCompletedEventArgs> OnRunCompleted { get; }
+        internal Action<OnRunCompletedEventArgs> OnRunCompleted { get; set; }
         internal TokenizationEvents TokenizationEvents { get; }
         internal BuildEvents BuildEvents { get; }
         internal IReadOnlyCollection<ExecutionMiddleware> MiddlewarePipeline { get; set; }
@@ -63,7 +56,6 @@ namespace CommandDotNet.Execution
             IDependencyResolver dependencyResolver, IHelpProvider helpProvider, 
             NameTransformation nameTransformation, Action<OnRunCompletedEventArgs> onRunCompleted,
             TokenizationEvents tokenizationEvents, BuildEvents buildEvents, IServices services,
-            CancellationToken cancellationToken,
             Dictionary<Type, Func<CommandContext, object>> parameterResolversByType)
         {
             AppSettings = appSettings;
@@ -75,7 +67,6 @@ namespace CommandDotNet.Execution
             TokenizationEvents = tokenizationEvents;
             BuildEvents = buildEvents;
             Services = services;
-            CancellationToken = cancellationToken;
             ParameterResolversByType = parameterResolversByType;
 
             ResolverService = services.GetOrAdd(() => new ResolverService());

--- a/CommandDotNet/Execution/CancellationHandlers.cs
+++ b/CommandDotNet/Execution/CancellationHandlers.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using CommandDotNet.Extensions;
+using CommandDotNet.Rendering;
+
+namespace CommandDotNet.Execution
+{
+    public static class CancellationHandlers
+    {
+        // using a stack to handle interactive sessions
+        // so ctrl+c for a long running interactive command
+        // stops only that command and not the interactive session
+        private static readonly Stack<CommandContext> SourceStack = new Stack<CommandContext>();
+
+        private class Handler
+        {
+            public CancellationTokenSource Source;
+            public bool IgnoreCtrlC;
+        }
+
+        private static Handler GetHandler(this CommandContext ctx) => ctx.Services.Get<Handler>();
+        private static void SetHandler(this CommandContext ctx, CancellationTokenSource src) => ctx.Services.Add(new Handler{Source = src});
+
+        static CancellationHandlers()
+        {
+            Console.CancelKeyPress += Console_CancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        }
+
+        internal static void BeginRun(CommandContext ctx)
+        {
+            var tokenSource = new CancellationTokenSource();
+            ctx.CancellationToken = tokenSource.Token;
+            ctx.SetHandler(tokenSource);
+            SourceStack.Push(ctx);
+        }
+
+        internal static void EndRun()
+        {
+            SourceStack.Pop();
+            if (!SourceStack.Any())
+            {
+                // the app will exit now
+                // clean up for tests
+                Console.CancelKeyPress -= Console_CancelKeyPress;
+                AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
+                AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
+            }
+        }
+
+        /// <summary>
+        /// Prefer <see cref="IConsole.TreatControlCAsInput"/> when possible.
+        /// Use this in cases where another component depends on the <see cref="Console.CancelKeyPress"/>
+        /// event and CommandDotNet should ignore the event during this time. 
+        /// </summary>
+        public static IDisposable IgnoreCtrlC()
+        {
+            // in case the feature isn't enabled but this is called.
+            if (!SourceStack.Any())
+            {
+                return DisposableAction.Null;
+            }
+
+            var handler = SourceStack.Peek().GetHandler();
+            handler.IgnoreCtrlC = true;
+            return new DisposableAction(() => handler.IgnoreCtrlC = false);
+        }
+
+        private static void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            var context = SourceStack.Peek();
+            var handler = context.GetHandler();
+            if (!handler.IgnoreCtrlC)
+            {
+                StopRun(context);
+                e.Cancel = true;
+            }
+        }
+
+        private static void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        {
+            Shutdown();
+        }
+
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.IsTerminating)
+            {
+                Shutdown();
+            }
+        }
+
+        private static void StopRun(CommandContext ctx)
+        {
+            var src = ctx.GetHandler().Source;
+            if (!src.IsCancellationRequested)
+            {
+                src.Cancel();
+            }
+        }
+
+        private static void Shutdown()
+        {
+            SourceStack.ForEach(StopRun);
+        }
+
+        internal static class TestAccess
+        {
+            internal static ConsoleCancelEventArgs Console_CancelKeyPress()
+            {
+                var args = Activate<ConsoleCancelEventArgs>(ConsoleSpecialKey.ControlC);
+                CancellationHandlers.Console_CancelKeyPress(null, args);
+                return args;
+            }
+
+            internal static void CurrentDomain_ProcessExit() =>
+                CancellationHandlers.CurrentDomain_ProcessExit(null, EventArgs.Empty);
+
+            internal static UnhandledExceptionEventArgs CurrentDomain_UnhandledException(bool isTerminating)
+            {
+                var ex = new Exception("some random exception");
+                var args = Activate<UnhandledExceptionEventArgs>(ex, isTerminating);
+                CancellationHandlers.CurrentDomain_UnhandledException(null, args);
+                return args;
+            }
+
+            internal static T Activate<T>(params object[] parameters)
+            {
+                var bindingFlags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.CreateInstance;
+                var parameterTypes = parameters.Select(p => p.GetType()).ToArray();
+                var constructorInfo = typeof(T).GetConstructor(bindingFlags, null, parameterTypes, null);
+                return (T)constructorInfo.Invoke(parameters);
+            }
+        }
+    }
+}

--- a/CommandDotNet/Execution/CancellationMiddleware.cs
+++ b/CommandDotNet/Execution/CancellationMiddleware.cs
@@ -1,70 +1,22 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading.Tasks;
 
 namespace CommandDotNet.Execution
 {
     internal static class CancellationMiddleware
     {
-        // This code is not covered by automation.  I couldn't find a way to mimic and verify these events.
-        // Tested manually using CancelMeApp in CommandDotNet.Examples
-
         internal static AppRunner UseCancellationHandlers(AppRunner appRunner)
         {
-            var handlers = new Handlers();
             return appRunner.Configure(c =>
             {
-                c.CancellationToken = handlers.CancellationToken;
-                c.OnRunCompleted += _ => handlers.RemoveHandlers();
+                c.OnRunCompleted += _ => CancellationHandlers.EndRun();
+                c.UseMiddleware(AddCancellationTokens, MiddlewareSteps.CancellationHandler);
             });
         }
 
-        private class Handlers
+        private static Task<int> AddCancellationTokens(CommandContext ctx, ExecutionDelegate next)
         {
-            private readonly CancellationTokenSource _tokenSource;
-
-            public CancellationToken CancellationToken => _tokenSource.Token;
-
-            internal Handlers()
-            {
-                _tokenSource = new CancellationTokenSource();
-                Console.CancelKeyPress += Console_CancelKeyPress;
-                AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
-                AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            }
-
-            internal void RemoveHandlers()
-            {
-                Console.CancelKeyPress -= Console_CancelKeyPress;
-                AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
-                AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
-            }
-
-            private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
-            {
-                Shutdown();
-                e.Cancel = true;
-            }
-
-            private void CurrentDomain_ProcessExit(object sender, EventArgs e)
-            {
-                Shutdown();
-            }
-
-            private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-            {
-                if (e.IsTerminating)
-                {
-                    Shutdown();
-                }
-            }
-
-            private void Shutdown()
-            {
-                if (!_tokenSource.IsCancellationRequested)
-                {
-                    _tokenSource.Cancel();
-                }
-            }
+            CancellationHandlers.BeginRun(ctx);
+            return next(ctx);
         }
     }
 }

--- a/CommandDotNet/Execution/ExecutionMiddlewareExtensions.cs
+++ b/CommandDotNet/Execution/ExecutionMiddlewareExtensions.cs
@@ -16,7 +16,7 @@ namespace CommandDotNet.Execution
                     (ctx, next) =>
                         first(ctx, c =>
                         {
-                            if (c.AppConfig.CancellationToken.IsCancellationRequested)
+                            if (c.CancellationToken.IsCancellationRequested)
                             {
                                 Log.Info("Cancellation requested. Aborting execution pipeline");
                                 return ExitCodes.Success;

--- a/CommandDotNet/Execution/MiddlewareSteps.cs
+++ b/CommandDotNet/Execution/MiddlewareSteps.cs
@@ -8,7 +8,12 @@
         /// <summary>
         /// Runs early in the <see cref="MiddlewareStages.PreTokenize"/> stage after <see cref="DebugDirective"/>
         /// </summary>
-        public static MiddlewareStep OnRunCompleted { get; } = DebugDirective + 1000;
+        public static MiddlewareStep CancellationHandler { get; } = DebugDirective + 1000;
+
+        /// <summary>
+        /// Runs early in the <see cref="MiddlewareStages.PreTokenize"/> stage after <see cref="CancellationHandler"/>
+        /// </summary>
+        public static MiddlewareStep OnRunCompleted { get; } = CancellationHandler + 1000;
 
         public static class DependencyResolver
         {

--- a/CommandDotNet/Extensions/DisposableAction.cs
+++ b/CommandDotNet/Extensions/DisposableAction.cs
@@ -4,7 +4,13 @@ namespace CommandDotNet.Extensions
 {
     internal class DisposableAction : IDisposable
     {
+        internal static DisposableAction Null { get; } = new DisposableAction();
+
         private readonly Action _action;
+
+        private DisposableAction()
+        {
+        }
 
         public DisposableAction(Action action)
         {
@@ -13,7 +19,7 @@ namespace CommandDotNet.Extensions
 
         public void Dispose()
         {
-            _action();
+            _action?.Invoke();
         }
     }
 }

--- a/CommandDotNet/Prompts/ValuePromptMiddleware.cs
+++ b/CommandDotNet/Prompts/ValuePromptMiddleware.cs
@@ -80,7 +80,7 @@ namespace CommandDotNet.Prompts
                 ))
                 .Where(a => argumentFilter == null || argumentFilter(a))
                 .Where(a => a.InputValues.IsEmpty() && (a.Default?.Value.IsNullValue() ?? true))
-                .TakeWhile(a => !commandContext.AppConfig.CancellationToken.IsCancellationRequested && !isCancellationRequested)
+                .TakeWhile(a => !commandContext.CancellationToken.IsCancellationRequested && !isCancellationRequested)
                 .ForEach(a =>
                 {
                     Log.Debug($"Prompting for {a.Name}");

--- a/docs/OtherFeatures/cancellation.md
+++ b/docs/OtherFeatures/cancellation.md
@@ -18,7 +18,7 @@ Traditionally, this is solved with a following steps:
 
 When enabled, the framework will:
 
-* set the `CommandContext.AppConfig.CancellationToken` with a new token.
+* set the `CommandContext.CancellationToken` with a new token.
 * register a [parameter resolver](../Extensibility/parameter-resolvers.md) for `CancellationToken`
 * cancel the token on
     * `Console.CancelKepPress`
@@ -44,3 +44,15 @@ public void MigrateRecords(CancellationToken cancellationToken, List<int> ids)
 
 !!! tip
     Remember to pass the CancellationToken to all database, web and service requests that take one.
+
+## Interactive sessions
+
+If you code a command to use an AppRunner to run another command, `Console.CancelKepPress` will cancel the token for the newest CommandContext.
+This enables cancelling long-running commands within an interactive session without cancelling the token for the command hosting the interactive session.
+
+See [the examples app](https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.Example/Examples.cs) 
+with [InteractiveSession.cs](https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.Example/InteractiveSession.cs)) 
+and [InteractiveMiddleware.cs](https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.Example/InteractiveMiddleware.cs)) 
+for an example of how to create an interactive session.
+
+In the future, we hope to have a CommandDotNet.ReadLine package offering an interactive session with all the goodness that comes with [ReadLine](https://github.com/tonerdo/readline) like autocomplete and history.

--- a/docs/ReleaseNotes/CommandDotNet.md
+++ b/docs/ReleaseNotes/CommandDotNet.md
@@ -28,6 +28,7 @@ Version 4 is focused on removing obsolete members and changing default behaviors
 
 * `CommandDotNet.Directives.Parse.ParseReporter` - moved to `CommandDotNet.Diagnostics.Parse.ParseReporter`
 * `CommandDotNet.Directives.Debugger` - moved to `CommandDotNet.Diagnostics.Debugger`
+* `AppConfig.CancellationToken` - moved to `CommandDotNet.CancellationToken`. This enables running nested commands within an interactive session.  See [Ctrl+C and CancellationToken](../OtherFeatures/cancellation.md#interactive-sessions) for more details.
 
 #### Removed or Replaced
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,7 @@ nav:
       - ReleaseNotes/CommandDotNet.IoC.MicrosoftDependencyInjection.md
       - ReleaseNotes/CommandDotNet.IoC.SimpleInjector.md
       - ReleaseNotes/CommandDotNet.NameCasing.md
-      - ReleaseNotes/CommandDotNet.NewerReleaseAlerts.md
+      - ReleaseNotes/CommandDotNet.NewerReleasesAlerts.md
       - ReleaseNotes/CommandDotNet.TestTools.md
     - Roadmap: 
       - ReleaseNotes/roadmap.md


### PR DESCRIPTION
- moved CancellationToken from AppConfig
- added InteractiveSession example to Example app
- CancellationHandlers handles nested runs
- increased test coverage