### PR TITLE
add [parse:raw] to show Environment.CommandLine

### DIFF
--- a/CommandDotNet.TestTools/AppRunnerTestExtensions.cs
+++ b/CommandDotNet.TestTools/AppRunnerTestExtensions.cs
@@ -144,7 +144,7 @@ namespace CommandDotNet.TestTools
             {
                 logLine("");
                 logLine($"{NewLine}Parse report <begin> ------------------------------");
-                ParseReporter.Report(context, logLine);
+                ParseReporter.Report(context, writeln: logLine);
                 logLine($"Parse report <end> ------------------------------{NewLine}");
             }
 

--- a/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseReporter_DefaultValues_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseReporter_DefaultValues_Tests.cs
@@ -64,7 +64,9 @@ options:
     inputs:
     default: source=EnvVar key=optList: four, five, six
 
-Use [parse:t] to include token transformations.
+Parse usage: [parse:t:raw] to include token transformations.
+ 't' to include token transformations.
+ 'raw' to include command line as passed to this process.
 "
                     }
                 });
@@ -106,7 +108,9 @@ options:
     inputs:
     default: one, two, three
 
-Use [parse:t] to include token transformations.
+Parse usage: [parse:t:raw] to include token transformations.
+ 't' to include token transformations.
+ 'raw' to include command line as passed to this process.
 "
                     }
                 });

--- a/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseReporter_InputValues_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseReporter_InputValues_Tests.cs
@@ -160,7 +160,9 @@ options:
     inputs: red (from: @{file} -> -l red), blue (from: @{file} -> -l blue), green (from: @{file} -> -l green)
     default:
 
-Use [parse:t] to include token transformations.
+Parse usage: [parse:t:raw] to include token transformations.
+ 't' to include token transformations.
+ 'raw' to include command line as passed to this process.
 "
                     }
                 });

--- a/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseReporter_Structure_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseReporter_Structure_Tests.cs
@@ -43,7 +43,9 @@ options:
     inputs:
     default:
 
-Use [parse:t] to include token transformations.
+Parse usage: [parse:t:raw] to include token transformations.
+ 't' to include token transformations.
+ 'raw' to include command line as passed to this process.
 "
                     }
                 });

--- a/CommandDotNet/Diagnostics/CommandLogger.cs
+++ b/CommandDotNet/Diagnostics/CommandLogger.cs
@@ -44,7 +44,7 @@ namespace CommandDotNet.Diagnostics
             sb.AppendLine();
 
             var indent = new Indent();
-            ParseReporter.Report(context, s => sb.AppendLine(s), indent);
+            ParseReporter.Report(context, writeln: s => sb.AppendLine(s), indent: indent);
 
             var additionalHeaders = config.AdditionalHeadersCallback?.Invoke(context);
             var otherConfigEntries = GetOtherConfigInfo(context, includeSystemInfo, additionalHeaders).ToList();

--- a/CommandDotNet/Diagnostics/Parse/ParseReporter.cs
+++ b/CommandDotNet/Diagnostics/Parse/ParseReporter.cs
@@ -11,8 +11,11 @@ namespace CommandDotNet.Diagnostics.Parse
         /// <summary>
         /// Reports the command and the source of values for all arguments 
         /// </summary>
-        public static void Report(CommandContext commandContext, 
-            Action<string?>? writeln = null, Indent? indent = null)
+        public static void Report(
+            CommandContext commandContext,
+            bool includeRawCommandLine = false,
+            Action<string?>? writeln = null, 
+            Indent? indent = null)
         {
             if (commandContext.ParseResult == null)
             {
@@ -24,6 +27,11 @@ namespace CommandDotNet.Diagnostics.Parse
             indent ??= new Indent();
             writeln ??= s => commandContext.Console.Out.WriteLine(s);
 
+            if (includeRawCommandLine)
+            {
+                writeln($"raw command line:{Environment.CommandLine}");
+            }
+            
             var path = command.GetPath();
             writeln($"{indent}command: {(path.IsNullOrWhitespace() ? "(root)" : path)}");
 

--- a/CommandDotNet/Diagnostics/ParseDirective.cs
+++ b/CommandDotNet/Diagnostics/ParseDirective.cs
@@ -48,15 +48,26 @@ namespace CommandDotNet.Diagnostics
                         : "Unable to map tokens to arguments. Falling back to token transformations.");
                     writer.WriteLine(parseContext.Transformations.ToString(), avoidExtraNewLine: true);
                 }
-                else if (parseContext.IncludeTokenization)
+                else if (parseContext.IncludeTokenization || parseContext.IncludeRawCommandLine)
                 {
-                    writer.WriteLine(parseContext.Transformations.ToString(), avoidExtraNewLine: true);
+                    if (parseContext.IncludeTokenization)
+                    {
+                        writer.WriteLine(parseContext.Transformations.ToString(), avoidExtraNewLine: true);
+                    }
+                    if (parseContext.IncludeRawCommandLine)
+                    {
+                        writer.WriteLine(Environment.CommandLine, avoidExtraNewLine: true);
+                    }
                 }
                 else
                 {
                     writer.WriteLine(null);
-                    writer.WriteLine($"Use [parse:{ParseContext.IncludeTransformationsArgName}]" +
+                    writer.WriteLine($"Parse usage: [parse:{ParseContext.IncludeTransformationsArgName}:{ParseContext.IncludeRawCommandLineArgName}]" +
+                                     " to include token transformations.");
+                    writer.WriteLine($" '{ParseContext.IncludeTransformationsArgName}'" +
                             " to include token transformations.");
+                    writer.WriteLine($" '{ParseContext.IncludeRawCommandLineArgName}'" +
+                                     " to include command line as passed to this process.");
                 }
 
                 return result;
@@ -79,7 +90,8 @@ namespace CommandDotNet.Diagnostics
             {
                 ParseReporter.Report(
                     commandContext, 
-                    s => commandContext.Console.Out.WriteLine(s));
+                    includeRawCommandLine: parseContext.IncludeRawCommandLine,
+                    writeln: s => commandContext.Console.Out.WriteLine(s));
                 parseContext.Reported = true;
                 return ExitCodes.Success;
             }
@@ -132,8 +144,10 @@ namespace CommandDotNet.Diagnostics
         private class ParseContext
         {
             internal const string IncludeTransformationsArgName = "t";
+            internal const string IncludeRawCommandLineArgName = "raw";
 
             internal bool IncludeTokenization;
+            internal bool IncludeRawCommandLine;
             internal bool Reported;
             internal readonly StringBuilder Transformations = new StringBuilder();
 
@@ -152,7 +166,8 @@ namespace CommandDotNet.Diagnostics
 
                 return new ParseContext
                 {
-                    IncludeTokenization = settings.ContainsKey(IncludeTransformationsArgName)
+                    IncludeTokenization = settings.ContainsKey(IncludeTransformationsArgName),
+                    IncludeRawCommandLine = settings.ContainsKey(IncludeRawCommandLineArgName)
                 };
             }
         }


### PR DESCRIPTION
this shows the command line before the .net process split
it into the `string[] args`. It can help to troubleshoot
issues others are having with the parsing