### PR TITLE
add %CmdPath% and %AppName% template variables for cmd help

### DIFF
--- a/CommandDotNet.Example/Examples.cs
+++ b/CommandDotNet.Example/Examples.cs
@@ -11,7 +11,7 @@ namespace CommandDotNet.Example
                            "\n" +
                            "directives must be specified before any commands and arguments.\n" +
                            "\n" +
-                           "Example: %UsageAppName% [debug] [parse] [log:info] cancel-me")]
+                           "Example: %AppName% [debug] [parse] [log:info] cancel-me")]
     internal class Examples
     {
         private static bool _inSession;

--- a/CommandDotNet.Tests/AppRunnerBuilderExtensions.cs
+++ b/CommandDotNet.Tests/AppRunnerBuilderExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace CommandDotNet.Tests
+{
+    public static class AppRunnerBuilderExtensions
+    {
+        public static AppRunner OnCommandCreated(this AppRunner appRunner, Action<Command> onCommandCreated)
+        {
+            return appRunner.Configure(cfg => 
+                cfg.BuildEvents.OnCommandCreated += args => 
+                    onCommandCreated(args.CommandBuilder.Command));
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/Help/CommandTemplatesTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Help/CommandTemplatesTests.cs
@@ -1,0 +1,77 @@
+using System;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Help
+{
+    public class CommandTemplatesTests
+    {
+        private const string AppName = "dotnet testhost.dll";
+
+        public CommandTemplatesTests(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [InlineData("%AppName% lala", "-h", "Usage: " + AppName + " lala")]
+        [InlineData("%CmdPath% lala", "-h", "Usage:  lala")]
+        [InlineData("%CmdPath% lala", "L1 -h", "Usage: L1 lala")]
+        [InlineData("%CmdPath% lala", "L1 L2 -h", "Usage: L1 L2 lala")]
+        [InlineData("%AppName% %CmdPath% lala", "L1 L2 -h", "Usage: " + AppName + " L1 L2 lala")]
+        [Theory]
+        public void InUsage(string usage, string input, string contains)
+        {
+            Run(usage, input, contains, cmd => { cmd.Usage = usage; });
+        }
+
+        [InlineData("%AppName% lala", "-h", AppName + " lala")]
+        [InlineData("%CmdPath% lala", "-h", " lala")]
+        [InlineData("%CmdPath% lala", "L1 -h", "L1 lala")]
+        [InlineData("%CmdPath% lala", "L1 L2 -h", "L1 L2 lala")]
+        [InlineData("%AppName% %CmdPath% lala", "L1 L2 -h", AppName + " L1 L2 lala")]
+        [Theory]
+        public void InDescription(string usage, string input, string contains)
+        {
+            Run(usage, input, contains, cmd => { cmd.Description = usage; });
+        }
+
+        [InlineData("%AppName% lala", "-h", AppName + " lala")]
+        [InlineData("%CmdPath% lala", "-h", " lala")]
+        [InlineData("%CmdPath% lala", "L1 -h", "L1 lala")]
+        [InlineData("%CmdPath% lala", "L1 L2 -h", "L1 L2 lala")]
+        [InlineData("%AppName% %CmdPath% lala", "L1 L2 -h", AppName + " L1 L2 lala")]
+        [Theory]
+        public void InExtendedHelpText(string usage, string input, string contains)
+        {
+            Run(usage, input, contains, cmd => { cmd.ExtendedHelpText = usage; });
+        }
+
+        private static void Run(string usage, string input, string contains, Action<Command> onCommandCreated)
+        {
+            new AppRunner<TemplateApp>()
+                .OnCommandCreated(onCommandCreated)
+                .Verify(new Scenario
+                {
+                    When = {Args = input},
+                    Then =
+                    {
+                        OutputContainsTexts = {contains}
+                    }
+                });
+        }
+
+        private class TemplateApp
+        {
+            [SubCommand]
+            public class L1
+            {
+                [SubCommand]
+                public class L2
+                {
+
+                }
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/Help/UsageAppNameStylesTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Help/UsageAppNameStylesTests.cs
@@ -46,21 +46,6 @@ namespace CommandDotNet.Tests.FeatureTests.Help
         }
 
         [Fact]
-        public void UsageAppNameTemplate_Should_ReplaceTemplateIn_Description_ExtendedHelp_UsageOverride()
-        {
-            new AppRunner<UsageAppNameTemplate>().Verify(new Scenario
-            {
-                When = {Args = "-h"},
-                Then = { OutputContainsTexts =
-                {
-                    "descr dotnet testhost.dll",
-                    "use dotnet testhost.dll",
-                    "ext dotnet testhost.dll"
-                } }
-            });
-        }
-
-        [Fact]
         public void UsageAppNameSettingUsedWhenProvided()
         {
             var appSettings = new AppSettings { Help = { UsageAppName = "WhatATool" } };
@@ -82,10 +67,7 @@ namespace CommandDotNet.Tests.FeatureTests.Help
 
         }
 
-        [Command(
-            Description = "descr %UsageAppName%",
-            Usage = "use %UsageAppName%",
-            ExtendedHelpText = "ext %UsageAppName%")]
+        [Command(Usage = "use %AppName%")]
         private class UsageAppNameTemplate
         {
 

--- a/CommandDotNet/Help/HelpTextProvider.cs
+++ b/CommandDotNet/Help/HelpTextProvider.cs
@@ -36,7 +36,7 @@ namespace CommandDotNet.Help
                            ?? $"{PadFront(AppName(command))}{PadFront(CommandPath(command))}"
                            + $"{PadFront(UsageSubcommand(command))}{PadFront(UsageOption(command))}{PadFront(UsageOperand(command))}"
                            + (command.GetArgumentSeparatorStrategy(_appSettings) == ArgumentSeparatorStrategy.PassThru ? " [[--] <arg>...]" : null);
-            return usage.Replace("%UsageAppName%", AppName(command));
+            return CommandReplacements(command, usage);
         }
 
         protected virtual string AppName(Command command) =>
@@ -96,7 +96,8 @@ namespace CommandDotNet.Help
                 ? "[command]"
                 : null;
 
-        protected virtual string? ExtendedHelpText(Command command) => command.ExtendedHelpText?.Replace("%UsageAppName%", AppName(command));
+        protected virtual string? ExtendedHelpText(Command command) => 
+            CommandReplacements(command, command.ExtendedHelpText);
 
         /// <summary>returns the body of the options section</summary> 
         protected virtual string? SectionOptions(Command command, bool includeInterceptorOptionsForExecutableCommands)
@@ -191,8 +192,8 @@ namespace CommandDotNet.Help
 
         protected virtual string CommandName(Command command) => command.Name;
 
-        protected virtual string? CommandDescription(Command command) => 
-            command.Description.UnlessNullOrWhitespace()?.Replace("%UsageAppName%", AppName(command));
+        protected virtual string? CommandDescription(Command command) =>
+            CommandReplacements(command, command.Description.UnlessNullOrWhitespace());
 
         protected virtual string? ArgumentName<T>(T argument) where T : IArgument =>
             argument.SwitchFunc(
@@ -262,6 +263,11 @@ namespace CommandDotNet.Help
 
         private ICollection<CommandHelpValues> BuildCommandHelpValues(IEnumerable<Command> commands) =>
             commands.Select(c => new CommandHelpValues(CommandName(c), CommandDescription(c))).ToCollection();
+
+        private string? CommandReplacements(Command command, string? text) => text?
+            .Replace("%UsageAppName%", AppName(command))
+            .Replace("%AppName%", AppName(command))
+            .Replace("%CmdPath%", command.GetPath());
 
         private class ArgumentHelpValues
         {

--- a/docs/Commands/commands.md
+++ b/docs/Commands/commands.md
@@ -62,9 +62,9 @@ public class Calculator
 
 ```bash
 ~
-$ dotnet add.dll Add --help
+$ dotnet calculator.dll sum --help
 
-dotnet example.dll sum -h
+dotnet calculator.dll sum -h
 sums two numbers
 
 Usage: sum <int> <int>
@@ -80,6 +80,32 @@ more details and examples
 ```
 
 Use `IgnoreUnexpectedOperands` & `ArgumentSeparatorStrategy` to override argument parsing behavior for the command. See [Argument Separator](../ArgumentValues/argument-separator.md) for more details.
+
+### Template variables
+
+Two template variables are available for use in Usage, Description and ExtendedHelpText: `%AppName%` and `%CmdPath%`
+
+#### AppName
+
+Use `%AppName%` to include the name as calculated by CommandDotNet. This will use `AppSettings.Help.UsageAppName` if it's set.
+
+```c#
+[Command(Usage ="%AppName% sum <int> <int>")]
+public class Calculator{ ... }
+```
+results in help with `Usage: dotnet calculator.dll sum <int> <int>`
+
+See this line `"Example: %AppName% [debug] [parse] [log:info] cancel-me"` in the [Example app](https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.Example/Examples.cs#L14).
+
+#### CmdPath
+
+Use `%CmdPath%` to include the full path of commands. This is helpful when working with subcommands.
+
+```c#
+[Command(Usage ="%CmdPath% <int> <int>")]
+public class Calculator{ ... }
+```
+results in help with `Usage: sum <int> <int>`
 
 ## Default Method
 

--- a/docs/Help/help.md
+++ b/docs/Help/help.md
@@ -99,11 +99,11 @@ When `Adaptive`, if the file name ends with ".exe", then uses `Executable` else 
 
 When specified, this value will be used and `UsageAppNameStyle` will be ignored.
 
-### %UsageAppName% Tempate
+### Template variables
 
-When you want to show usage examples in a command description, extended help or overridden usage section, use `%UsageAppName%`. This text will be replaced usage app name from one of the options above.  
+The CommandAttribute supports the use of template variables to be used in help.
 
-See this line `"Example: %UsageAppName% [debug] [parse] [log:info] cancel-me"` in the [Example app](https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.Example/Examples.cs#L14).
+See docs for [Commands > Template variables](../Commands/commands.md#template-variables) for details.
 
 ## Custom Help Provider
 


### PR DESCRIPTION
keeping %UsageAppName% for backwards compatibility but
removing all references to it.

adding OnCommandCreated test help that I may move to
TestTools to make it easier to update commands for tests.