### PR TITLE
exitcode=1 when help shown for non-executable command

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/ClassCommands/SubCommandTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ClassCommands/SubCommandTests.cs
@@ -52,6 +52,7 @@ namespace CommandDotNet.Tests.FeatureTests.ClassCommands
                     When = { Args = null },
                     Then =
                     {
+                        ExitCode = ExitCodes.Error.Result,
                         Output = @"Usage: dotnet testhost.dll [command]
 
 Commands:

--- a/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseDirectiveVerifier.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParseDirective/ParseDirectiveVerifier.cs
@@ -40,9 +40,10 @@ namespace CommandDotNet.Tests.FeatureTests.ParseDirective
 
             args ??= "";
 
+            var helpRequested = args == "-h" || args.Contains(" -h") || args.Contains("-h ");
+            
             ContainsIf(showsHelp, "Usage: dotnet testhost.dll ");
-            ContainsIf(args == "-h" || args.Contains(" -h") || args.Contains("-h "),
-                "Help requested. Only token transformations are available.");
+            ContainsIf(helpRequested, "Help requested. Only token transformations are available.");
             ContainsIf(showsTokens, @"token transformations:
 
 >>> from shell");
@@ -98,7 +99,7 @@ namespace CommandDotNet.Tests.FeatureTests.ParseDirective
                     When = {Args = $"{parse} {args}"},
                     Then =
                     {
-                        ExitCode = throwBeforeBind ? 1 : 0,
+                        ExitCode = throwBeforeBind || (showsHelp && !helpRequested) ? 1 : 0,
                         Output = expectedResult,
                         OutputContainsTexts = contains,
                         OutputNotContainsTexts = notContains

--- a/CommandDotNet/Help/HelpMiddleware.cs
+++ b/CommandDotNet/Help/HelpMiddleware.cs
@@ -61,7 +61,7 @@ namespace CommandDotNet.Help
             if (!targetCommand.IsExecutable)
             {
                 ctx.ShowHelpOnExit = true;
-                return ExitCodes.Success;
+                return ExitCodes.Error;
             }
 
             return next(ctx);

--- a/CommandDotNet/TypeDescriptors/DelegatedTypeDescriptor.cs
+++ b/CommandDotNet/TypeDescriptors/DelegatedTypeDescriptor.cs
@@ -9,8 +9,8 @@ namespace CommandDotNet.TypeDescriptors
 
         public DelegatedTypeDescriptor(string displayName, Func<string, object> parseValueDelegate)
         {
-            _displayName = displayName;
-            _parseValueDelegate = parseValueDelegate;
+            _displayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+            _parseValueDelegate = parseValueDelegate ?? throw new ArgumentNullException(nameof(parseValueDelegate));
         }
 
         public bool CanSupport(Type type)


### PR DESCRIPTION
This is the way all other programs work. Help middleware
will only return Success if help was requested.