### PR TITLE
verify empty string supported as argument value

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/ParseTests/BasicParseTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ParseTests/BasicParseTests.cs
@@ -115,6 +115,32 @@ namespace CommandDotNet.Tests.FeatureTests.ParseTests
             });
         }
 
+        [Fact]
+        public void EmptyStringCanBeUsedForOptionValues()
+        {
+            new AppRunner<App>().Verify(new Scenario
+            {
+                When = { Args = "Add -o \"\" 0 0" },
+                Then =
+                {
+                    AssertContext = ctx => ctx.ParamValuesShouldBe(0,0,"",10)
+                }
+            });
+        }
+
+        [Fact]
+        public void EmptyStringCanBeUsedForOperandValues()
+        {
+            new AppRunner<App>().Verify(new Scenario
+            {
+                When = { Args = "Do \"\"" },
+                Then =
+                {
+                    AssertContext = ctx => ctx.ParamValuesShouldBe("")
+                }
+            });
+        }
+
         private class App
         {
             public void Add(int x, int y, 

--- a/CommandDotNet.Tests/FeatureTests/SuggestionRankingExtensionsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/SuggestionRankingExtensionsTests.cs
@@ -86,5 +86,17 @@ namespace CommandDotNet.Tests.FeatureTests
                 .Should()
                 .BeEquivalentSequenceTo(expectedSuggestions.Split(","));
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("/t")]
+        public void GivenWhitespace(string typo)
+        {
+            "one,two".Split(",")
+                .RankAndTrimSuggestions(typo, 5)
+                .Should()
+                .BeEmpty();
+        }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/Suggestions/AllowedValuesTypoSuggestionsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Suggestions/AllowedValuesTypoSuggestionsTests.cs
@@ -36,6 +36,27 @@ See 'dotnet testhost.dll Eat --help'"
         }
 
         [Fact]
+        public void Given_OperandValueTypo_OfEmptyString_DoesNotSuggest_AndHelpIsShown()
+        {
+            new AppRunner<CafeApp>()
+                .UseTypoSuggestions()
+                .Verify(new Scenario
+                {
+                    When = { Args = "Eat \"\"" },
+                    Then =
+                    {
+                        ExitCode = 1,
+                        OutputContainsTexts =
+                        {
+                            @"Unrecognized value '' for argument: meal
+
+Usage: dotnet testhost.dll Eat [options] <meal>"
+                        }
+                    }
+                });
+        }
+
+        [Fact]
         public void Given_OptionValueTypo_SuggestAllowedValues()
         {
             new AppRunner<CafeApp>()
@@ -54,6 +75,27 @@ Did you mean ...
    Cherry
 
 See 'dotnet testhost.dll Eat --help'"
+                        }
+                    }
+                });
+        }
+
+        [Fact]
+        public void Given_OptionValueTypo_OfEmptyString_DoesNotSuggest_AndHelpIsShown()
+        {
+            new AppRunner<CafeApp>()
+                .UseTypoSuggestions()
+                .Verify(new Scenario
+                {
+                    When = { Args = "Eat Dinner --fruit \"\"" },
+                    Then =
+                    {
+                        ExitCode = 1,
+                        OutputContainsTexts =
+                        {
+                            @"Unrecognized value '' for option: fruit
+
+Usage: dotnet testhost.dll Eat [options] <meal>"
                         }
                     }
                 });

--- a/CommandDotNet.Tests/FeatureTests/Suggestions/OptionAndSubcommandTypoSuggestionsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Suggestions/OptionAndSubcommandTypoSuggestionsTests.cs
@@ -6,9 +6,9 @@ using Xunit.Abstractions;
 
 namespace CommandDotNet.Tests.FeatureTests.Suggestions
 {
-    public class TypoSuggestionsTests
+    public class OptionAndSubcommandTypoSuggestionsTests
     {
-        public TypoSuggestionsTests(ITestOutputHelper output)
+        public OptionAndSubcommandTypoSuggestionsTests(ITestOutputHelper output)
         {
             Ambient.Output = output;
         }
@@ -153,35 +153,7 @@ See 'dotnet testhost.dll User --help'
         }
 
         [Fact]
-        public void Given_ValueTypo_ShowsSimilarCommands()
-        {
-            new AppRunner<App>()
-                .UseTypoSuggestions()
-                .Verify(
-                    new Scenario
-                    {
-                        When = {Args = "egister"},
-                        Then =
-                        {
-                            ExitCode = 1,
-                            OutputContainsTexts =
-                            {
-                                @"'egister' is not a valid subcommand
-
-Did you mean ...
-   Register
-   Unregister
-   User
-
-See 'dotnet testhost.dll  --help'
-"
-                            }
-                        }
-                    });
-        }
-
-        [Fact]
-        public void Given_ValueType_AndManySimilarOptions_LimitResult()
+        public void Given_OptionTypo_AndManySimilarOptions_LimitResult()
         {
             new AppRunner<App>()
                 .UseTypoSuggestions(3)
@@ -209,7 +181,7 @@ See 'dotnet testhost.dll Similars --help'
         }
 
         [Fact]
-        public void Given_ValueType_NoSimilarOptions_ShowsHelp()
+        public void Given_OptionTypo_NoSimilarOptions_ShowsHelp()
         {
             new AppRunner<App>()
                 .UseTypoSuggestions()
@@ -217,6 +189,77 @@ See 'dotnet testhost.dll Similars --help'
                     new Scenario
                     {
                         When = {Args = "Similars --lala"},
+                        Then =
+                        {
+                            ExitCode = 1,
+                            OutputContainsTexts =
+                            {
+                                "Unrecognized option '--lala'"
+                            }
+                        }
+                    });
+        }
+
+        [Fact]
+        public void Given_ValueTypo_ShowsSimilarCommands()
+        {
+            new AppRunner<App>()
+                .UseTypoSuggestions()
+                .Verify(
+                    new Scenario
+                    {
+                        When = { Args = "egister" },
+                        Then =
+                        {
+                            ExitCode = 1,
+                            OutputContainsTexts =
+                            {
+                                @"'egister' is not a valid subcommand
+
+Did you mean ...
+   Register
+   Unregister
+   User
+
+See 'dotnet testhost.dll  --help'
+"
+                            }
+                        }
+                    });
+        }
+
+        [Fact]
+        public void Given_ValueTypo_OfEmptyString_DoesNotSuggest_AndHelpIsShown()
+        {
+            new AppRunner<App>()
+                .UseTypoSuggestions()
+                .Verify(
+                    new Scenario
+                    {
+                        When = { Args = "\"\"" },
+                        Then =
+                        {
+                            ExitCode = 1,
+                            OutputContainsTexts =
+                            {
+                                @"Unrecognized command or argument ''
+
+Usage: dotnet testhost.dll [command]
+"
+                            }
+                        }
+                    });
+        }
+
+        [Fact]
+        public void Given_ValueTypo_OfEmptyString_ShowsHelp()
+        {
+            new AppRunner<App>()
+                .UseTypoSuggestions()
+                .Verify(
+                    new Scenario
+                    {
+                        When = { Args = "Similars --lala" },
                         Then =
                         {
                             ExitCode = 1,

--- a/CommandDotNet/Parsing/Typos/TypoSuggestionsMiddleware.cs
+++ b/CommandDotNet/Parsing/Typos/TypoSuggestionsMiddleware.cs
@@ -63,6 +63,15 @@ namespace CommandDotNet.Parsing.Typos
 
         private static bool TrySuggestValues(CommandContext ctx, NotAllowedValueParseError notAllowedValue)
         {
+            if (notAllowedValue.Token.Value == "")
+            {
+                return false;
+            }
+
+            // TODO: how to handle list values?
+            //       duplicate values may be allowed in some cases but probably not the norm
+            //       should this excluded values that could result in duplicates?
+            //       add an option to allow/prevent duplicates for list arguments?
             return TrySuggest(ctx, notAllowedValue.Command, notAllowedValue.Token.Value,
                 notAllowedValue.Argument.AllowedValues.ToCollection(),
                 $"is not a valid {notAllowedValue.Argument.TypeInfo.DisplayName}", 
@@ -71,6 +80,11 @@ namespace CommandDotNet.Parsing.Typos
 
         private static bool TrySuggestArgumentNames(CommandContext ctx, Command command, Token token)
         {
+            if (token.Value == "")
+            {
+                return false;
+            }
+
             ICollection<string> GetOptionNames()
             {
                 // skip short names
@@ -106,12 +120,6 @@ namespace CommandDotNet.Parsing.Typos
             }
 
             var config = ctx.AppConfig.Services.GetOrThrow<Config>();
-
-            // TODO: allowed values
-            //   if the next value should be a value for an option, include allowed values for the option.
-            //   else include allowed values of the next expected operand
-            //      fyi: the next expected operand could be a list operand that already has values.
-            //           logic should remain the same, just be sure to include this test case
 
             var suggestions = candidates
                 .RankAndTrimSuggestions(typo, config.MaxSuggestionCount)


### PR DESCRIPTION
Added test to ensure empty string can be passed as an
argument value for core functionality.

Fix bug in TypoSuggest that threw an exception when
the token value was an empty string. Empty string will
skip suggestions and the error will be shown to the
user