### PR TITLE
Stops displaying Password values in help text

### DIFF
--- a/CommandDotNet/Help/HelpTextProvider.cs
+++ b/CommandDotNet/Help/HelpTextProvider.cs
@@ -218,7 +218,7 @@ namespace CommandDotNet.Help
 
             return defaultValue.IsNullValue() 
                 ? null 
-                : $"[{defaultValue!.ValueToString()}]";
+                : $"[{defaultValue!.ValueToString( argument.TypeInfo.Type == typeof(Password) )}]";
         }
 
         /// <summary>Row with default indent of 2 spaces</summary>


### PR DESCRIPTION
I found this problem, by adding an option of `Password` type with the `EnvVar` attribute.
The default help text generator displays the default value with no consideration for the type

https://github.com/bilal-fazlani/commanddotnet/blob/14c8ca20ceef44db4dab3a6eb6c403dccf7c53b4/CommandDotNet/Help/HelpTextProvider.cs#L221

I verified that replacing the above line with

```cs
        : $"[{defaultValue!.ValueToString( argument.TypeInfo.Type == typeof(Password) )}]";
```

solves the issue.