### PR TITLE
fix cases where adding cmdctx to ex.Data throws ex

### DIFF
--- a/CommandDotNet/Diagnostics/ExceptionExtensions.cs
+++ b/CommandDotNet/Diagnostics/ExceptionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿
 using System;
 using System.Collections;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -14,13 +13,13 @@ namespace CommandDotNet.Diagnostics
     {
         internal static void SetCommandContext(this Exception ex, CommandContext ctx)
         {
-            ex.Data[typeof(CommandContext)] = ctx;
+            ex.Data[typeof(CommandContext)] = new NonSerializableWrapper<CommandContext>(ctx);
         }
 
         public static CommandContext? GetCommandContext(this Exception ex)
         {
             return ex.Data.Contains(typeof(CommandContext))
-                ? (CommandContext)ex.Data[typeof(CommandContext)]
+                ? ((NonSerializableWrapper<CommandContext>)ex.Data[typeof(CommandContext)]).Item
                 : ex.InnerException?.GetCommandContext();
         }
 

--- a/CommandDotNet/Diagnostics/NonSerializableWrapper.cs
+++ b/CommandDotNet/Diagnostics/NonSerializableWrapper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace CommandDotNet.Diagnostics
+{
+    /// <summary>
+    /// A NonSerializableWrapper is a wrapper to contain non-serializable objects
+    /// within Exception.Data which requires all items to be serializable.
+    /// This is required for older versions of the dotnet.
+    /// </summary>
+    [Serializable]
+    internal class NonSerializableWrapper<T> : ISerializable
+    {
+        public T Item { get; }
+
+        public NonSerializableWrapper(T item)
+        {
+            Item = item;
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => 
+            info.AddValue(typeof(T).Name, Item?.ToString());
+    }
+}


### PR DESCRIPTION
This is a problem with older .net frameworks where items
added to ex.Data must be serializable.  That was intended
to support remoting which is not supported in .net core

fixes #331 