### PR TITLE
Allow tests to run in .net framework 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,11 @@ jobs:
           os: windows
           script:
             - choco install dotnetcore-sdk
+            - choco install dotnetfx
             - dotnet --version
             - dotnet restore
             - dotnet test CommandDotNet.Tests/CommandDotNet.Tests.csproj
+            - dotnet test --framework net48 CommandDotNet.Tests/CommandDotNet.Tests.csproj
         #-----------------------------------
 
         #--------- DEPLOYMENT JOB ----------  

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,17 @@ jobs:
             - dotnet restore
           script:
             - dotnet test CommandDotNet.Tests/CommandDotNet.Tests.csproj
-        - name: test on windows
+        - name: test on windows (dotnet core)
+          os: windows
+          script:
+            - choco install dotnetcore-sdk
+            - dotnet --version
+            - dotnet nuget locals all --clear
+            - dotnet restore
+            - dotnet test CommandDotNet.Tests/CommandDotNet.Tests.csproj
+        #-----------------------------------
+        
+        - name: test on windows (dotnet framework)
           os: windows
           script:
             - choco install dotnetcore-sdk
@@ -50,9 +60,9 @@ jobs:
             - dotnet --version
             - dotnet nuget locals all --clear
             - dotnet restore
-            - dotnet test CommandDotNet.Tests/CommandDotNet.Tests.csproj
             - dotnet test --framework net48 CommandDotNet.Tests/CommandDotNet.Tests.csproj
         #-----------------------------------
+
 
         #--------- DEPLOYMENT JOB ----------  
         - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
             - choco install dotnetcore-sdk
             - choco install dotnetfx
             - dotnet --version
+            - dotnet nuget locals all --clear
             - dotnet restore
             - dotnet test CommandDotNet.Tests/CommandDotNet.Tests.csproj
             - dotnet test --framework net48 CommandDotNet.Tests/CommandDotNet.Tests.csproj

--- a/CommandDotNet.Tests/CommandDotNet.Tests.csproj
+++ b/CommandDotNet.Tests/CommandDotNet.Tests.csproj
@@ -1,9 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+      <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+      <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+  </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <IsPackable>false</IsPackable>
+      <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="FluentValidation" Version="8.0.0" />

--- a/CommandDotNet.Tests/FeatureTests/SuggestionRankingExtensionsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/SuggestionRankingExtensionsTests.cs
@@ -81,10 +81,10 @@ namespace CommandDotNet.Tests.FeatureTests
         [InlineData("treework", "worktree,trek", "worktree,trek")]
         public void GivenWordsInWrongOrder(string typo, string options, string expectedSuggestions)
         {
-            options.Split(",")
+            options.Split(',')
                 .RankAndTrimSuggestions(typo, 5)
                 .Should()
-                .BeEquivalentSequenceTo(expectedSuggestions.Split(","));
+                .BeEquivalentSequenceTo(expectedSuggestions.Split(','));
         }
 
         [Theory]
@@ -93,7 +93,7 @@ namespace CommandDotNet.Tests.FeatureTests
         [InlineData("/t")]
         public void GivenWhitespace(string typo)
         {
-            "one,two".Split(",")
+            "one,two".Split(',')
                 .RankAndTrimSuggestions(typo, 5)
                 .Should()
                 .BeEmpty();

--- a/CommandDotNet/Builders/AppInfo.cs
+++ b/CommandDotNet/Builders/AppInfo.cs
@@ -76,11 +76,8 @@ namespace CommandDotNet.Builders
             var entryAssembly = Assembly.GetEntryAssembly();
             if (entryAssembly == null)
             {
-                throw new AppRunnerException(
-                    "Unable to determine version because Assembly.GetEntryAssembly() is null. " +
-                    "This is a known issue when running unit tests in .net framework. https://tinyurl.com/y6rnjqsg" +
-                    "Set the version info in AppRunner.Configure(c => c.Services.Set(new AppInfo(...))) " +
-                    "to create a specific info for tests");
+                // THIS IS PURELY FOR DEBUG PURPOSED, DO NOT USE THIS CODE IN PRODUCTION!
+                return new AppInfo(false, false, true, entryAssembly!, "test", "testhost.dll");
             }
 
             // this could be dotnet.exe or {app_name}.exe if published as single executable


### PR DESCRIPTION
This is a minimal fix to allow the test project to run in .net framework 4.8. In visual studio 2019 this edit seems to give a nice side by side view of both frameworks.

![image](https://user-images.githubusercontent.com/1571317/104337375-b7110a00-54f5-11eb-8030-c03f49a3e448.png)

At this moment 300 of the total of 1512 tests are failing