### PR TITLE
Make it easy to print AppInfo

### DIFF
--- a/CommandDotNet/Builders/AppInfo.cs
+++ b/CommandDotNet/Builders/AppInfo.cs
@@ -14,7 +14,7 @@ namespace CommandDotNet.Builders
     /// For unit tests, use `AppRunner.Configure(c =&gt; c.Services.Set(new AppInfo(...)))`
     /// to set to specific version
     /// </summary>
-    public class AppInfo : ICloneable
+    public class AppInfo : ICloneable, IIndentableToString
     {
         private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
 
@@ -143,6 +143,16 @@ namespace CommandDotNet.Builders
         public object Clone()
         {
             return new AppInfo(IsExe, IsSelfContainedExe, IsRunViaDotNetExe, EntryAssembly, FilePath, FileName, _version);
+        }
+
+        public override string ToString()
+        {
+            return ToString(new Indent());
+        }
+
+        public string ToString(Indent indent)
+        {
+            return this.ToStringFromPublicProperties(indent);
         }
     }
 }

--- a/CommandDotNet/Execution/AppConfig.cs
+++ b/CommandDotNet/Execution/AppConfig.cs
@@ -101,7 +101,7 @@ namespace CommandDotNet.Execution
                 .ToCsv(NewLine);
 
             return $"{nameof(AppConfig)}:{NewLine}" +
-                   $"{indent}{AppSettings.ToString(indent.Increment())}{NewLine}" +
+                   $"{indent}{AppSettings.ToString(indent2)}{NewLine}" +
                    $"{indent}DependencyResolver: {DependencyResolver}{NewLine}" +
                    $"{indent}HelpProvider: {HelpProvider}{NewLine}" +
                    $"{indent}TokenTransformations:{NewLine}{tokenTransformations}{NewLine}" +

--- a/CommandDotNet/Extensions/ObjectExtensions.cs
+++ b/CommandDotNet/Extensions/ObjectExtensions.cs
@@ -7,7 +7,7 @@ using static System.Environment;
 
 namespace CommandDotNet.Extensions
 {
-    internal static class ObjectExtensions
+    public static class ObjectExtensions
     {
         internal static bool IsNullValue(this object? obj)
         {
@@ -39,7 +39,7 @@ namespace CommandDotNet.Extensions
             return value.ToString();
         }
 
-        internal static string ToStringFromPublicProperties(this object item, Indent? indent = null)
+        public static string ToStringFromPublicProperties(this object item, Indent? indent = null)
         {
             if (item == null)
             {


### PR DESCRIPTION
And make ToStringFromPublicProperties public for cases
where a class does not yet use it.

Fix a possible format bug in AppConfig.ToString