### PR TITLE
expose DefaultSources.GetValueFunc for host apps

### DIFF
--- a/docs/ArgumentValues/default-values-from-config.md
+++ b/docs/ArgumentValues/default-values-from-config.md
@@ -94,6 +94,30 @@ To specify defaults for a specific command, prefix the key with the command name
 <add key="download -p" value="secret2"/>
 ```
 
+## .Net Core Config
+Enable the feature with `appRunner.UseDefaultsFromConfig(...)` and use the pattern below
+
+```c#
+var appConfig = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", true, true)
+    .Build();
+
+var evConfig = new ConfigurationBuilder()
+    .AddEnvironmentVariables()
+    .Build();
+
+new AppRunner<App>()
+    .UseDefaultsFromConfig(DefaultSources.GetValueFunc("AppSetting", 
+        key => appConfig[key],
+        DefaultSources.AppSetting.GetKeyFromAttribute
+        // includeNamingConventions as described above
+        DefaultSources.AppSetting.GetKeysFromConvention))
+    .UseDefaultsFromConfig(DefaultSources.GetValueFunc("EnvVar", key => evConfig[key]))
+    .Run(args)
+```
+
+Creating two different configs allows us to determine the source of the default value 
+for the [Parse directive](../Diagnostics/parse-directive.md) and the [CommandLogger](../Diagnostics/command-logger.md)
 
 ## Other Configs
 Enable the feature with `appRunner.UseDefaultsFromConfig(arg => ...)`

--- a/docs/ReleaseNotes/CommandDotNet.md
+++ b/docs/ReleaseNotes/CommandDotNet.md
@@ -1,5 +1,17 @@
 # CommandDotNet
 
+## 4.1.8
+
+Expose expose DefaultSources.GetValueFunc for host apps to reuse logic for alternate configuration sources.
+
+See the new [.Net Core Config](../ArgumentValues/default-values-from-config.md#.net-core-config) section for an example.
+
+## 4.1.7
+
+AppInfo.ToString will print out all properties making it easier to gather info for diagnostics.
+
+Expose object.ToStringFromPublicProperties to make it easier to output other classes for diagnostics.
+
 ## 4.1.6
 
 Add AppInfo.SetResolver to enable overriding for tests to get a consistent AppName. See [Deterministic AppName for tests](../TestTools/Tools/deterministic-appinfo.md) for details.


### PR DESCRIPTION
This will make it easier to reuse the logic for other
configuration sources like .net core configs.

Add examples to docs and update release notes

Add xmldocs for the public DefaultSources members