### PR TITLE
favor Concat over Union where possible

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromMultipleSourcesTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/ArgumentDefaults/DefaultFromMultipleSourcesTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using CommandDotNet.Tests.Utils;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.ArgumentDefaults
+{
+    public class DefaultFromMultipleSourcesTests
+    {
+        public DefaultFromMultipleSourcesTests(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [Fact]
+        public void UsesDefaultFromTheFirstSourceAvailable()
+        {
+            new AppRunner<App>()
+                .UseDefaultsFromAppSetting(new NameValueCollection
+                {
+                    {"opt1", "from AppSetting"}
+                })
+                .UseDefaultsFromEnvVar(new Dictionary<string,string>
+                {
+                    { "opt1", "from EnvVar" },
+                    { "opt2", "from EnvVar" }
+                })
+                .UseDefaultsFromConfig(arg => Config(arg, "from Config"))
+                .Verify(new Scenario
+                {
+                    When = { Args = "Do" },
+                    Then = { AssertContext = ctx => ctx.ParamValuesShouldBe("from AppSetting", "from EnvVar", "from Config") }
+                });
+        }
+
+
+        private static ArgumentDefault? Config(IArgument argument, string value)
+        {
+            return argument.TypeInfo == TypeInfo.Flag
+                ? null
+                : new ArgumentDefault("test", "key", value);
+        }
+
+        public class App
+        {
+            public void Do(
+                [AppSetting("opt1")]
+                [EnvVar("opt1")]
+                [Option] string option1 = "from param",
+
+                [AppSetting("opt2")]
+                [EnvVar("opt2")]
+                [Option] string option2 = "from param",
+
+                [AppSetting("opt3")]
+                [EnvVar("opt3")]
+                [Option] string option3 = "from param"
+            )
+            {
+
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/Arguments/BigArgumentsSetsTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/BigArgumentsSetsTests.cs
@@ -424,7 +424,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
             var modelOptions = range.Select(i => $"[Option]\npublic int {i.ModelOption} {{ get; set; }}");
             var modelArgs = range.Select(i => $"[Operand]\npublic int {i.ModelArg} {{ get; set; }}");
             _output.WriteLine("public class Model : IArgumentModel\n{");
-            _output.WriteLine(modelOptions.Union(modelArgs).ToCsv(Environment.NewLine));
+            _output.WriteLine(modelOptions.Concat(modelArgs).ToCsv(Environment.NewLine));
             _output.WriteLine("}");
         }
     }

--- a/CommandDotNet.Tests/FeatureTests/EnabledMiddlewareScenarios/SetDefaultsTestMiddleware.cs
+++ b/CommandDotNet.Tests/FeatureTests/EnabledMiddlewareScenarios/SetDefaultsTestMiddleware.cs
@@ -33,7 +33,7 @@ namespace CommandDotNet.Tests.FeatureTests.EnabledMiddlewareScenarios
             var command = context.ParseResult.TargetCommand;
             var interceptor = command.Parent;
 
-            var arguments = command.Options.Cast<IArgument>().Union(command.Operands);
+            var arguments = command.Options.Cast<IArgument>().Concat(command.Operands);
             if (interceptor is { })
             {
                 arguments = arguments.Union(interceptor.Options).Union(interceptor.Operands);

--- a/CommandDotNet/Builders/ArgumentDefaults/SetArgumentDefaultsMiddleware.cs
+++ b/CommandDotNet/Builders/ArgumentDefaults/SetArgumentDefaultsMiddleware.cs
@@ -28,7 +28,7 @@ namespace CommandDotNet.Builders.ArgumentDefaults
                 else
                 {
                     config.GetDefaultValueCallbacks =
-                        config.GetDefaultValueCallbacks.Union(getDefaultValueCallbacks).ToArray();
+                        config.GetDefaultValueCallbacks.Concat(getDefaultValueCallbacks).ToArray();
                 }
             });
         }

--- a/CommandDotNet/ClassModeling/BindValuesMiddleware.cs
+++ b/CommandDotNet/ClassModeling/BindValuesMiddleware.cs
@@ -17,7 +17,7 @@ namespace CommandDotNet.ClassModeling
             var parserFactory = new ParserFactory(commandContext.AppConfig.AppSettings);
 
             var arguments = commandContext.InvocationPipeline.All
-                .SelectMany(ic => ic.Command.Options.Cast<IArgument>().Union(ic.Command.Operands));
+                .SelectMany(ic => ic.Command.Options.Cast<IArgument>().Concat(ic.Command.Operands));
 
             if (arguments.Any(a => !TryBindArgument(a, console, parserFactory)))
             {

--- a/CommandDotNet/Tokens/TokenizerPipeline.cs
+++ b/CommandDotNet/Tokens/TokenizerPipeline.cs
@@ -61,11 +61,11 @@ namespace CommandDotNet.Tokens
                     {
                         new TokenTransformation(
                             "expand-clubbed-flags",
-                            Int32.MaxValue,
+                            int.MaxValue,
                             ExpandClubbedOptionsTransformation.Transform),
                         new TokenTransformation(
                             "split-option-assignments",
-                            Int32.MaxValue,
+                            int.MaxValue,
                             SplitOptionsTransformation.Transform)
                     })
                 .ToArray();


### PR DESCRIPTION
- improves performance
- in SetArgumentDefaultsMiddleware could prevent
cases where callbacks are filtered out