### PR TITLE
Spectre Argument Prompter

### DIFF
--- a/CommandDotNet.Spectre.Testing/AnsiTestConsole.cs
+++ b/CommandDotNet.Spectre.Testing/AnsiTestConsole.cs
@@ -36,11 +36,11 @@ namespace CommandDotNet.Spectre.Testing
 
         public ITestConsole Mock(IEnumerable<string> pipedInput, bool overwrite = false)
         {
-            //_testConsole.Mock(pipedInput, overwrite);
-            foreach (var input in pipedInput)
-            {
-                SpectreTestConsole.Input.PushTextWithEnter(input);
-            }
+            _testConsole.Mock(pipedInput, overwrite);
+            // foreach (var input in pipedInput)
+            // {
+            //     SpectreTestConsole.Input.PushTextWithEnter(input);
+            // }
             return this;
         }
 

--- a/CommandDotNet.Spectre.Testing/AnsiTestConsole.cs
+++ b/CommandDotNet.Spectre.Testing/AnsiTestConsole.cs
@@ -12,14 +12,14 @@ namespace CommandDotNet.Spectre.Testing
 {
     public class AnsiTestConsole : ITestConsole, IAnsiConsole
     {
-        private readonly SpectreTestConsole _spectreTestConsole;
+        internal SpectreTestConsole SpectreTestConsole { get; }
         private readonly AnsiConsoleForwardingConsole _forwardingConsole;
         private readonly TestConsole _testConsole;
 
         public AnsiTestConsole()
         {
-            _spectreTestConsole = new SpectreTestConsole();
-            _forwardingConsole = new AnsiConsoleForwardingConsole(_spectreTestConsole);
+            SpectreTestConsole = new SpectreTestConsole();
+            _forwardingConsole = new AnsiConsoleForwardingConsole(SpectreTestConsole);
             _testConsole = new TestConsole();
         }
 
@@ -28,15 +28,19 @@ namespace CommandDotNet.Spectre.Testing
         // the SpectreTestConsole converts line endings to \n which can break assertions against literal strings in tests.
         // convert them back to Environment.NewLine
 
-        public string AllText() => _spectreTestConsole.Output.Replace("\n", Environment.NewLine);
+        public string AllText() => SpectreTestConsole.Output.Replace("\n", Environment.NewLine);
 
-        public string OutText() => _spectreTestConsole.Output.Replace("\n", Environment.NewLine);
+        public string OutText() => SpectreTestConsole.Output.Replace("\n", Environment.NewLine);
 
-        public string ErrorText() => _spectreTestConsole.Output.Replace("\n", Environment.NewLine);
+        public string ErrorText() => SpectreTestConsole.Output.Replace("\n", Environment.NewLine);
 
         public ITestConsole Mock(IEnumerable<string> pipedInput, bool overwrite = false)
         {
-            _testConsole.Mock(pipedInput, overwrite);
+            //_testConsole.Mock(pipedInput, overwrite);
+            foreach (var input in pipedInput)
+            {
+                SpectreTestConsole.Input.PushTextWithEnter(input);
+            }
             return this;
         }
 
@@ -58,30 +62,30 @@ namespace CommandDotNet.Spectre.Testing
 
         #region Spectre.TestConsole members
 
-        public void Clear(bool home) => _spectreTestConsole.Clear();
+        public void Clear(bool home) => SpectreTestConsole.Clear();
 
-        public void Write(IRenderable renderable) => _spectreTestConsole.Write(renderable);
+        public void Write(IRenderable renderable) => SpectreTestConsole.Write(renderable);
 
-        public Profile Profile => _spectreTestConsole.Profile;
+        public Profile Profile => SpectreTestConsole.Profile;
 
         IAnsiConsoleInput IAnsiConsole.Input => Input;
 
-        public IExclusivityMode ExclusivityMode => _spectreTestConsole.ExclusivityMode;
+        public IExclusivityMode ExclusivityMode => SpectreTestConsole.ExclusivityMode;
 
-        public TestConsoleInput Input => _spectreTestConsole.Input;
+        public TestConsoleInput Input => SpectreTestConsole.Input;
 
-        public RenderPipeline Pipeline => _spectreTestConsole.Pipeline;
+        public RenderPipeline Pipeline => SpectreTestConsole.Pipeline;
 
-        public IAnsiConsoleCursor Cursor => _spectreTestConsole.Cursor;
+        public IAnsiConsoleCursor Cursor => SpectreTestConsole.Cursor;
 
-        public string Output => _spectreTestConsole.Output;
+        public string Output => SpectreTestConsole.Output;
 
-        public IReadOnlyList<string> Lines => _spectreTestConsole.Lines;
+        public IReadOnlyList<string> Lines => SpectreTestConsole.Lines;
 
         public bool EmitAnsiSequences
         {
-            get => _spectreTestConsole.EmitAnsiSequences;
-            set => _spectreTestConsole.EmitAnsiSequences = value;
+            get => SpectreTestConsole.EmitAnsiSequences;
+            set => SpectreTestConsole.EmitAnsiSequences = value;
         }
 
         #endregion

--- a/CommandDotNet.Spectre.Testing/TestConsoleExtensions.cs
+++ b/CommandDotNet.Spectre.Testing/TestConsoleExtensions.cs
@@ -1,0 +1,69 @@
+﻿using Spectre.Console;
+using Spectre.Console.Testing;
+
+namespace CommandDotNet.Spectre.Testing
+{
+    /// <summary>
+    /// Contains extensions for <see cref="AnsiTestConsole"/> to delegate to Spectre's <see cref="TestConsole"/>
+    /// </summary>
+    public static class TestConsoleExtensions
+    {
+        /// <summary>
+        /// Sets the console's color system.
+        /// </summary>
+        /// <param name="console">The console.</param>
+        /// <param name="colors">The color system to use.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static AnsiTestConsole Colors(this AnsiTestConsole console, ColorSystem colors)
+        {
+            console.SpectreTestConsole.Colors(colors);
+            return console;
+        }
+
+        /// <summary>
+        /// Sets whether or not ANSI is supported.
+        /// </summary>
+        /// <param name="console">The console.</param>
+        /// <param name="enable">Whether or not VT/ANSI control codes are supported.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static AnsiTestConsole SupportsAnsi(this AnsiTestConsole console, bool enable)
+        {
+            console.SpectreTestConsole.SupportsAnsi(enable);
+            return console;
+        }
+
+        /// <summary>
+        /// Makes the console interactive.
+        /// </summary>
+        /// <param name="console">The console.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static AnsiTestConsole Interactive(this AnsiTestConsole console)
+        {
+            console.SpectreTestConsole.Interactive();
+            return console;
+        }
+
+        /// <summary>
+        /// Sets the console width.
+        /// </summary>
+        /// <param name="console">The console.</param>
+        /// <param name="width">The console width.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static AnsiTestConsole Width(this AnsiTestConsole console, int width)
+        {
+            console.SpectreTestConsole.Width(width);
+            return console;
+        }
+
+        /// <summary>
+        /// Turns on emitting of VT/ANSI sequences.
+        /// </summary>
+        /// <param name="console">The console.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static AnsiTestConsole EmitAnsiSequences(this AnsiTestConsole console)
+        {
+            console.SpectreTestConsole.EmitAnsiSequences();
+            return console;
+        }
+    }
+}

--- a/CommandDotNet.Spectre.Testing/TestConsoleInputExtensions.cs
+++ b/CommandDotNet.Spectre.Testing/TestConsoleInputExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Spectre.Console.Testing;
+
+namespace CommandDotNet.Spectre.Testing
+{
+    public static class TestConsoleInputExtensions
+    {
+        public static void PushTextsWithEnter(this TestConsoleInput testConsoleInput, params string[] inputs)
+        {
+            foreach (var input in inputs)
+            {
+                testConsoleInput.PushTextWithEnter(input);
+            }
+        }
+        public static void PushCharacters(this TestConsoleInput testConsoleInput, string inputs)
+        {
+            foreach (var input in inputs)
+            {
+                testConsoleInput.PushCharacter(input);
+            }
+        }
+        public static void PushKeys(this TestConsoleInput testConsoleInput, params ConsoleKey[] inputs)
+        {
+            foreach (var input in inputs)
+            {
+                testConsoleInput.PushKey(input);
+            }
+        }
+    }
+}

--- a/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
+++ b/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommandDotNet.Prompts;
+using Spectre.Console;
+
+namespace CommandDotNet.Spectre
+{
+    public class SpectreArgumentPrompter : IArgumentPrompter
+    {
+        private readonly int _defaultPageSize;
+        private readonly Func<CommandContext, IArgument, string>? _getPromptTextCallback;
+
+        public SpectreArgumentPrompter(
+            int defaultPageSize = 10,
+            Func<CommandContext, IArgument, string>? getPromptTextCallback = null)
+        {
+            _defaultPageSize = defaultPageSize;
+            _getPromptTextCallback = getPromptTextCallback;
+        }
+
+        public virtual ICollection<string> PromptForArgumentValues(
+            CommandContext ctx, IArgument argument, out bool isCancellationRequested)
+        {
+            isCancellationRequested = false;
+
+            var argumentName = _getPromptTextCallback?.Invoke(ctx, argument) ?? argument.Name;
+            var promptText = $"{argumentName} ({argument.TypeInfo.DisplayName})";
+            var isPassword = argument.TypeInfo.UnderlyingType == typeof(Password);
+            var defaultValue = argument.Default?.Value;
+            
+            var ansiConsole = ctx.Services.GetOrThrow<IAnsiConsole>();
+            // https://spectreconsole.net/prompts/
+
+            if (argument.Arity.AllowsMany())
+            {
+                if (argument.AllowedValues.Any())
+                {
+                    var p = new MultiSelectionPrompt<string>()
+                        .Title(promptText)
+                        .AddChoices(argument.AllowedValues)
+                        .PageSize(_defaultPageSize)
+                        .MoreChoicesText($"[grey](Move up and down to reveal more {argument.TypeInfo.DisplayName})[/]")
+                        .InstructionsText(
+                            "[grey](Press [blue]<space>[/] to toggle a fruit, " +
+                            "[green]<enter>[/] to accept)[/]");
+                    return ansiConsole.Prompt(p);
+                }
+                else
+                {
+                    // TODO: how to prompt multiple free hand? use old prompter? Loop Prompt until no value returned? 
+                    //       Ask spectre community? 
+                    //       comma separated?  first non-alpha-numeric is separater, else comma?
+                    // TODO: how to show default? is it the first choice?
+                    throw new NotImplementedException("prompting for free-entry lists not yet supported");
+                    return Array.Empty<string>();
+                }
+            }
+            else
+            {
+                if (argument.TypeInfo.Type == typeof(bool))
+                {
+                    if (defaultValue != null)
+                    {
+                        ansiConsole.Confirm(promptText, (bool)defaultValue);
+                    }
+                    else
+                    {
+                        ansiConsole.Confirm(promptText);
+                    }
+                }
+                if (argument.AllowedValues.Any())
+                {
+                    var p = new SelectionPrompt<string>()
+                        {
+                            Title = promptText,
+                            PageSize = _defaultPageSize,
+                            MoreChoicesText = $"[grey](Move up and down to reveal more {argument.TypeInfo.DisplayName})[/]"
+                        }
+                        .AddChoices(argument.AllowedValues);
+                    
+                    // TODO: how to show default? is it the first choice?
+
+                    return new []{ ansiConsole.Prompt(p) };
+                }
+                else
+                {
+                    var p = new TextPrompt<string>(promptText)
+                    {
+                        IsSecret = isPassword,
+                        AllowEmpty = argument.Arity.AllowsNone(),
+                        ShowDefaultValue = true
+                    };
+                    if (defaultValue != null)
+                    {
+                        p.DefaultValue(defaultValue.ToString());
+                    }
+                    return new[] { ansiConsole.Prompt(p) };
+                }
+            }
+        }
+    }
+}

--- a/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
+++ b/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
@@ -36,24 +36,20 @@ namespace CommandDotNet.Spectre
             {
                 if (argument.AllowedValues.Any())
                 {
+                    // TODO: how to show default? is it the first choice?
                     var p = new MultiSelectionPrompt<string>()
                         .Title(promptText)
                         .AddChoices(argument.AllowedValues)
-                        .PageSize(_defaultPageSize)
-                        .MoreChoicesText($"[grey](Move up and down to reveal more {argument.TypeInfo.DisplayName})[/]")
-                        .InstructionsText(
-                            "[grey](Press [blue]<space>[/] to toggle a fruit, " +
-                            "[green]<enter>[/] to accept)[/]");
+                        .PageSize(_defaultPageSize);
+                        //.MoreChoicesText($"[grey](Move up and down to reveal more {argument.TypeInfo.DisplayName})[/]")
+                        // .InstructionsText(
+                        //     "[grey](Press [blue]<space>[/] to toggle a fruit, " +
+                        //     "[green]<enter>[/] to accept)[/]");
                     return ansiConsole.Prompt(p);
                 }
                 else
                 {
-                    // TODO: how to prompt multiple free hand? use old prompter? Loop Prompt until no value returned? 
-                    //       Ask spectre community? 
-                    //       comma separated?  first non-alpha-numeric is separater, else comma?
-                    // TODO: how to show default? is it the first choice?
-                    throw new NotImplementedException("prompting for free-entry lists not yet supported");
-                    return Array.Empty<string>();
+                    return MultiPrompt(ansiConsole, promptText);
                 }
             }
             else
@@ -94,6 +90,23 @@ namespace CommandDotNet.Spectre
                     }
                     return new[] { ansiConsole.Prompt(p) };
                 }
+            }
+        }
+
+        private List<string> MultiPrompt(IAnsiConsole ansiConsole, string prompt)
+        {
+            var answers = new List<string>();
+            ansiConsole.WriteLine(prompt);
+            while (true)
+            {
+                var textPrompt = new TextPrompt<string>("> ") { AllowEmpty = true };
+                var answer = ansiConsole.Prompt(textPrompt);
+                if (string.IsNullOrEmpty(answer))
+                {
+                    return answers;
+                }
+
+                answers.Add(answer);
             }
         }
     }

--- a/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
+++ b/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
@@ -60,14 +60,11 @@ namespace CommandDotNet.Spectre
             {
                 if (argument.TypeInfo.Type == typeof(bool))
                 {
-                    if (defaultValue != null)
-                    {
-                        ansiConsole.Confirm(promptText, (bool)defaultValue);
-                    }
-                    else
-                    {
-                        ansiConsole.Confirm(promptText);
-                    }
+                    var result = defaultValue != null
+                        ? ansiConsole.Confirm(promptText, (bool)defaultValue)
+                        : ansiConsole.Confirm(promptText);
+
+                    return new[] { result.ToString() };
                 }
                 if (argument.AllowedValues.Any())
                 {

--- a/CommandDotNet.Spectre/SpectreMiddleware.cs
+++ b/CommandDotNet.Spectre/SpectreMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using CommandDotNet.Rendering;
+﻿using System;
+using CommandDotNet.Prompts;
+using CommandDotNet.Rendering;
 using Spectre.Console;
 
 namespace CommandDotNet.Spectre
@@ -9,11 +11,28 @@ namespace CommandDotNet.Spectre
         {
             return appRunner.Configure(c =>
             {
-                var console = ansiConsole ?? AnsiConsole.Console;
+                ansiConsole ??= AnsiConsole.Console;
 
-                c.Console = ansiConsole as IConsole ?? new AnsiConsoleForwardingConsole(console);
-                c.UseParameterResolver(ctx => console);
-                c.Services.Add(console);
+                c.Console = ansiConsole as IConsole ?? new AnsiConsoleForwardingConsole(ansiConsole);
+                c.UseParameterResolver(ctx => ansiConsole);
+                c.Services.Add(ansiConsole);
+            });
+        }
+
+        public static AppRunner UseSpectreToPromptForMissingArguments(this AppRunner appRunner,
+            int defaultPageSize = 10,
+            Func<CommandContext, IArgument, string>? argumentPromptTextOverride = null,
+            Predicate<IArgument>? argumentFilter = null)
+        {
+            return appRunner.Configure(c =>
+            {
+                if (!c.Services.Contains<IAnsiConsole>())
+                {
+                    throw new InvalidConfigurationException(
+                        $"must register {nameof(UseSpectreAnsiConsole)} to ensure an {nameof(IAnsiConsole)} is available.");
+                }
+                c.Services.Add<IArgumentPrompter>(new SpectreArgumentPrompter(defaultPageSize, argumentPromptTextOverride));
+                appRunner.UsePrompting(argumentFilter: argumentFilter);
             });
         }
     }

--- a/CommandDotNet.Tests/CommandDotNet.Spectre/SpectreArgumentPrompterTests.cs
+++ b/CommandDotNet.Tests/CommandDotNet.Spectre/SpectreArgumentPrompterTests.cs
@@ -1,0 +1,432 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandDotNet.Spectre;
+using CommandDotNet.Spectre.Testing;
+using CommandDotNet.Tests.Utils;
+using CommandDotNet.TestTools.Prompts;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.CommandDotNet.Spectre
+{
+    public class SpectreArgumentPrompterTests
+    {
+        public SpectreArgumentPrompterTests(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [Fact]
+        public void WhenOperandAndOptionProvided_DoesNotPrompt()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("lala");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)} something --opt1 simple",
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("simple", "something"),
+                        Output = ""
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenOptionMissing_PromptsOnlyForOption()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("simple");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)} something"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("simple", "something"),
+                        Output = @"opt1 (Text) simple
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenOperandMissing_PromptsOnlyForOperand()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("something");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)} --opt1 simple",
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("simple", "something"),
+                        Output = @"arg1 (Text) something
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenOptionAndOperandMissing_PromptsForBoth()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextsWithEnter("something", "simple");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("simple", "something"),
+                        Output = @"arg1 (Text) something
+opt1 (Text) simple
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenOperandListProvided_DoesNotPrompt()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("lala");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.DoList)} something simple"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(new List<string>{"something", "simple"}),
+                        Output = ""
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenOperandListMissing_Prompts()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextsWithEnter("something", "simple");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.DoList)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(new List<string>{"something", "simple"}),
+                        Output = @"args (Text) [<enter> once to begin new value. <enter> twice to finish]: 
+something
+simple
+
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void ListPrompt_CanIncludeQuotes()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextsWithEnter("something", "simple", "'or not'", "\"so simple\"");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.DoList)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(
+                            new List<string>{"something", "simple", "'or not'", "\"so simple\""}),
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenInterceptorOptionMissing_Prompts()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("1");
+
+            new AppRunner<HierApp>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(HierApp.Do)} --inherited1 2",
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe<HierApp>(1, 2)
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenInheritedOptionMissing_Prompts()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("2");
+
+            new AppRunner<HierApp>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $" --intercept1 1 {nameof(HierApp.Do)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe<HierApp>(1, 2)
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenPasswordMissing_PromptMasksInput()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextsWithEnter("lala", "fishies");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Secure)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("lala", new Password("fishies")),
+                        Output = @"user (Text) lala
+password (Text) *******
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenFlagsMissing_DoesNotPrompt()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextsWithEnter("y", "y");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Flags)}"
+                    },
+                    Then = { AssertContext = ctx => ctx.ParamValuesShouldBe(null, null)}
+                });
+        }
+
+        [Fact]
+        public void WhenExplicitBoolOptionMissing_Prompts()
+        {
+            var testConsole = new AnsiTestConsole().Interactive();
+            testConsole.Input.PushTextWithEnter("y"); 
+            testConsole.Input.PushTextWithEnter("y");
+
+            new AppRunner<App>(new AppSettings { BooleanMode = BooleanMode.Explicit })
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Flags)}"
+                    },
+                    Then = {AssertContext = ctx => ctx.ParamValuesShouldBe(true, true)}
+                });
+        }
+
+        [Fact]
+        public void WhenBoolOperandMissing_Prompts()
+        {
+            var testConsole = new AnsiTestConsole().Interactive();
+            testConsole.Input.PushCharacter('y');
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Bool)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(true),
+                        Output = @"operand1 (Boolean) [y/n] (y): y
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void CanOverridePromptText()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("fishies");
+            testConsole.Input.PushTextWithEnter("fishies");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments(argumentPromptTextOverride: (ctx, arg) => "lala")
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)}",
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("fishies", "fishies"),
+                        Output = @"lala (Text) fishies
+lala (Text) fishies
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void CanFilterListOfArgumentsForPrompting()
+        {
+            var testConsole = new AnsiTestConsole();
+            testConsole.Input.PushTextWithEnter("something");
+
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole(testConsole)
+                .UseSpectreToPromptForMissingArguments(argumentFilter: arg => arg.Name == "arg1")
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)}"
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(null, "something"),
+                        Output = @"arg1 (Text) something
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void PipedInputIsEvaluatedBeforePrompting()
+        {
+            var pipedInput = new[] { "a", "b", "c" };
+            new AppRunner<App>()
+                .UseSpectreAnsiConsole()
+                .UseSpectreToPromptForMissingArguments()
+                .AppendPipedInputToOperandList()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.DoList)}",
+                        PipedInput = pipedInput,
+                        OnPrompt = Respond.FailOnPrompt()
+                    },
+                    Then = {AssertContext = ctx => ctx.ParamValuesShouldBe(pipedInput.ToList())}
+                });
+        }
+
+        class App
+        {
+            public void Do([Option] string opt1, string arg1)
+            {
+            }
+
+            public void DoList(List<string> args)
+            {
+            }
+
+            public void Secure(string user, Password password)
+            {
+            }
+
+            public void Flags(
+                [Option(ShortName = "a", LongName = null)] bool flagA,
+                [Option(ShortName = "b", LongName = null)] bool flagB)
+            {
+            }
+
+            public void Bool(bool operand1)
+            {
+            }
+        }
+
+        class HierApp
+        {
+            public Task<int> Intercept(InterceptorExecutionDelegate next, 
+                int intercept1, 
+                [Option(AssignToExecutableSubcommands = true)] int inherited1)
+            {
+                return next();
+            }
+
+            public void Do()
+            {
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/CommandDotNet.Spectre/SpectreArgumentPrompterTests.cs
+++ b/CommandDotNet.Tests/CommandDotNet.Spectre/SpectreArgumentPrompterTests.cs
@@ -300,7 +300,7 @@ password (Text) *******
         public void WhenBoolOperandMissing_Prompts()
         {
             var testConsole = new AnsiTestConsole().Interactive();
-            testConsole.Input.PushCharacter('y');
+            testConsole.Input.PushTextWithEnter("y");
 
             new AppRunner<App>()
                 .UseSpectreAnsiConsole(testConsole)

--- a/CommandDotNet.Tests/CommandDotNet.Spectre/SpectreArgumentPrompterTests.cs
+++ b/CommandDotNet.Tests/CommandDotNet.Spectre/SpectreArgumentPrompterTests.cs
@@ -142,7 +142,7 @@ opt1 (Text) simple
         public void WhenOperandListMissing_Prompts()
         {
             var testConsole = new AnsiTestConsole();
-            testConsole.Input.PushTextsWithEnter("something", "simple");
+            testConsole.Input.PushTextsWithEnter("something", "simple", "");
 
             new AppRunner<App>()
                 .UseSpectreAnsiConsole(testConsole)
@@ -156,10 +156,10 @@ opt1 (Text) simple
                     Then =
                     {
                         AssertContext = ctx => ctx.ParamValuesShouldBe(new List<string>{"something", "simple"}),
-                        Output = @"args (Text) [<enter> once to begin new value. <enter> twice to finish]: 
-something
-simple
-
+                        Output = @"args (Text)
+> something
+> simple
+> 
 "
                     }
                 });
@@ -169,7 +169,7 @@ simple
         public void ListPrompt_CanIncludeQuotes()
         {
             var testConsole = new AnsiTestConsole();
-            testConsole.Input.PushTextsWithEnter("something", "simple", "'or not'", "\"so simple\"");
+            testConsole.Input.PushTextsWithEnter("something", "simple", "'or not'", "\"so simple\"", "");
 
             new AppRunner<App>()
                 .UseSpectreAnsiConsole(testConsole)


### PR DESCRIPTION
To prompt for missing arguments.   This works mostly as expected.  We have a problem on the last Confirm for bool arguments and we need to determine the pattern to prompt for free-text lists