### PR TITLE
CommandContext.Services falls back to AppConfig.Services

### DIFF
--- a/CommandDotNet/CommandContext.cs
+++ b/CommandDotNet/CommandContext.cs
@@ -62,7 +62,7 @@ namespace CommandDotNet
         /// Services registered for the lifetime of the <see cref="CommandContext"/>.<br/>
         /// Can be used to store state for coordination between middleware and across middleware stages.
         /// </summary>
-        public IServices Services { get; } = new Services();
+        public IServices Services { get; }
 
         /// <summary>
         /// The application <see cref="IDependencyResolver"/>.<br/>
@@ -83,6 +83,7 @@ namespace CommandDotNet
             Tokens = originalTokens;
             AppConfig = appConfig;
             Console = appConfig.Console;
+            Services = new Services(appConfig.Services);
         }
 
         public override string ToString()


### PR DESCRIPTION
It's cumbersome and error prone for devs when they
resolve a service they set in config and it fails because
they were resolving from the context services instead
of the appconfig services.  We can simplify that.