### PR TITLE
support types with string ctor/Parse with optional params

### DIFF
--- a/CommandDotNet.Tests/UnitTests/TypeDescriptors/StringCtorTypeDescriptorTest.cs
+++ b/CommandDotNet.Tests/UnitTests/TypeDescriptors/StringCtorTypeDescriptorTest.cs
@@ -1,0 +1,53 @@
+﻿using CommandDotNet.TypeDescriptors;
+using FluentAssertions;
+using Xunit;
+
+namespace CommandDotNet.Tests.UnitTests.TypeDescriptors
+{
+    public class StringCtorTypeDescriptorTest
+    {
+        [Fact]
+        public void CanSupport_ctor_with_single_string()
+        {
+            new StringCtorTypeDescriptor().CanSupport(typeof(StringCtor)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CanSupport_static_parse_method_with_single_string()
+        {
+            new StringCtorTypeDescriptor().CanSupport(typeof(StaticParse)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CanSupport_static_parse_method_with_single_required_param_of_type_string()
+        {
+            new StringCtorTypeDescriptor().CanSupport(typeof(StaticParseWithOptional)).Should().BeTrue();
+        }
+
+        public class StringCtor
+        {
+            public string Value { get; }
+
+            public StringCtor(string value)
+            {
+                Value = value;
+            }
+        }
+
+        public class StaticParse
+        {
+            public string Value { get; private set; }
+
+            public static StaticParse Parse(string value) 
+                => new StaticParse { Value = value };
+        }
+
+        public class StaticParseWithOptional
+        {
+            public string Value { get; private set; }
+
+            public static StaticParseWithOptional Parse(string value, bool optional = true) => 
+                new StaticParseWithOptional { Value = value };
+        }
+    }
+}

--- a/CommandDotNet/TypeDescriptors/ComponentModelTypeDescriptor.cs
+++ b/CommandDotNet/TypeDescriptors/ComponentModelTypeDescriptor.cs
@@ -21,7 +21,7 @@ namespace CommandDotNet.TypeDescriptors
             var typeConverter = argument.Arity.AllowsMany()
                 ? TypeDescriptor.GetConverter(argument.TypeInfo.UnderlyingType)
                 : TypeDescriptor.GetConverter(argument.TypeInfo.Type);
-            return typeConverter.ConvertFrom(value);
+            return typeConverter.ConvertFrom(value)!;
         }
     }
 }

--- a/CommandDotNet/TypeDescriptors/StringCtorTypeDescriptor.cs
+++ b/CommandDotNet/TypeDescriptors/StringCtorTypeDescriptor.cs
@@ -16,7 +16,7 @@ namespace CommandDotNet.TypeDescriptors
 
         public string GetDisplayName(IArgument argument)
         {
-            return GetConverter(argument).MethodBase.GetParameters().Single().Name;
+            return GetConverter(argument).MethodBase!.GetParameters().Single().Name;
         }
 
         public object ParseString(IArgument argument, string value)
@@ -39,7 +39,7 @@ namespace CommandDotNet.TypeDescriptors
             static bool HasSingleStringArgument(MethodBase method)
             {
                 var parameterInfos = method.GetParameters();
-                return parameterInfos.Length == 1 && parameterInfos.First().ParameterType == typeof(string);
+                return parameterInfos.Count(p => p.ParameterType == typeof(string) && !p.IsOptional) == 1;
             }
             
             return Cache.GetOrAdd(type, t =>

--- a/docs/Arguments/argument-types.md
+++ b/docs/Arguments/argument-types.md
@@ -3,9 +3,11 @@
 Arguments can be defined with any type that...
 
 * is a primitive type: 
-* contains a string constructor
 * has a TypeConverter
-* has a `public static Parse(string)` method
+* contains a string constructor
+* has a `public static Parse(string)` method or `public static Parse(string, {optional paremeters})`
+  
+The constructor and static Parse method may contain additional optional parameters but must contain only a single required string parameter.
 
 Includes, but not limited to:
 


### PR DESCRIPTION
string ctor and static Parse methods were supported,
but now the methods can contain additional optional params