### PR TITLE
implement support for NRT

### DIFF
--- a/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
+++ b/CommandDotNet.Spectre/SpectreArgumentPrompter.cs
@@ -91,7 +91,7 @@ namespace CommandDotNet.Spectre
                     var p = new TextPrompt<string>(promptText)
                     {
                         IsSecret = isPassword,
-                        AllowEmpty = argument.Arity.AllowsNone(),
+                        AllowEmpty = argument.Arity.RequiresNone(),
                         ShowDefaultValue = true
                     };
                     if (defaultValue != null)

--- a/CommandDotNet.TestTools/TrackingInvocation.cs
+++ b/CommandDotNet.TestTools/TrackingInvocation.cs
@@ -17,6 +17,7 @@ namespace CommandDotNet.TestTools
         public IReadOnlyCollection<ParameterInfo> Parameters => _backingInvocation.Parameters;
         public object[] ParameterValues => _backingInvocation.ParameterValues;
         public MethodInfo MethodInfo => _backingInvocation.MethodInfo;
+        public bool IsInterceptor => _backingInvocation.IsInterceptor;
         public IReadOnlyCollection<IArgumentModel> FlattenedArgumentModels => _backingInvocation.FlattenedArgumentModels;
 
         public TrackingInvocation(IInvocation backingInvocation)

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsEnumListArgumentModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsEnumListArgumentModel.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace CommandDotNet.Tests.FeatureTests.Arguments.Models.ArgsAsArgModels
 {
-    public class OperandsNoDefaultsEnumListArgumentModel : IEnumListArgumentModel
+    public class NrtOperandsNoDefaultsEnumListArgumentModel : IEnumListArgumentModel
     {
         [Operand]
-        public List<DayOfWeek> EnumListArg { get; set; }
+        public List<DayOfWeek>? EnumListArg { get; set; }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsObjectListArgumentModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsObjectListArgumentModel.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace CommandDotNet.Tests.FeatureTests.Arguments.Models.ArgsAsArgModels
 {
-    public class OperandsNoDefaultsEnumListArgumentModel : IEnumListArgumentModel
+    public class NrtOperandsNoDefaultsObjectListArgumentModel : IObjectListArgumentModel
     {
         [Operand]
-        public List<DayOfWeek> EnumListArg { get; set; }
+        public List<Uri>? ObjectListArg { get; set; }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsSampleTypesModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsSampleTypesModel.cs
@@ -3,27 +3,31 @@ using System.Collections.Generic;
 
 namespace CommandDotNet.Tests.FeatureTests.Arguments.Models.ArgsAsArgModels
 {
-    public class OperandsNoDefaultsSampleTypesModel : ISampleTypesArgumentsModel
+    public class NrtOperandsNoDefaultsSampleTypesModel : ISampleTypesArgumentsModel
     {
+        [Obsolete("no value here")]
         [Operand]
         public bool BoolArg { get; set; }
 
         [Operand]
-        public string StringArg { get; set; }
+        public string? StringArg { get; set; }
 
+        [Obsolete("no value here")]
         [Operand]
         public int StructArg { get; set; }
 
+        [Obsolete("no value here")]
         [Operand]
         public int? StructNArg { get; set; }
 
+        [Obsolete("no value here")]
         [Operand]
         public DayOfWeek EnumArg { get; set; }
 
         [Operand]
-        public Uri ObjectArg { get; set; }
+        public Uri? ObjectArg { get; set; }
 
         [Operand]
-        public List<string> StringListArg { get; set; }
+        public List<string>? StringListArg { get; set; }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsStructListArgumentModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/NrtOperandsNoDefaultsStructListArgumentModel.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 
 namespace CommandDotNet.Tests.FeatureTests.Arguments.Models.ArgsAsArgModels
 {
-    public class OperandsNoDefaultsStructListArgumentModel : IStructListArgumentModel
+    public class NrtOperandsNoDefaultsStructListArgumentModel : IStructListArgumentModel
     {
         [Operand]
-        public List<int> StructListArg { get; set; }
+        public List<int>? StructListArg { get; set; }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/OperandsNoDefaultsObjectListArgumentModel.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Models/ArgsAsArgModels/OperandsNoDefaultsObjectListArgumentModel.cs
@@ -6,6 +6,6 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments.Models.ArgsAsArgModels
     public class OperandsNoDefaultsObjectListArgumentModel : IObjectListArgumentModel
     {
         [Operand]
-        public List<Uri>? ObjectListArg { get; set; }
+        public List<Uri> ObjectListArg { get; set; }
     }
 }

--- a/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_NRT_NoDefaults_Tests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Arguments/Operands_DefinedAsArgModel_NRT_NoDefaults_Tests.cs
@@ -10,12 +10,12 @@ using Xunit.Abstractions;
 
 namespace CommandDotNet.Tests.FeatureTests.Arguments
 {
-    public class Operands_DefinedAsArgModel_NoDefaults_Tests
+    public class Operands_DefinedAsArgModel_NRT_NoDefaults_Tests
     {
         private static readonly AppSettings BasicHelp = TestAppSettings.BasicHelp;
         private static readonly AppSettings DetailedHelp = TestAppSettings.DetailedHelp;
 
-        public Operands_DefinedAsArgModel_NoDefaults_Tests(ITestOutputHelper output)
+        public Operands_DefinedAsArgModel_NRT_NoDefaults_Tests(ITestOutputHelper output)
         {
             Ambient.Output = output;
         }
@@ -25,7 +25,7 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
         {
             new AppRunner<OperandsNoDefaults>().Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} -h" },
                 Then =
                 {
                     AssertContext = ctx =>
@@ -37,9 +37,9 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
                         cmd.Find<IArgument>("StructNArg")!.Default.Should().BeNull();
                         cmd.Find<IArgument>("EnumArg")!.Default.Should().BeNull();
                         cmd.Find<IArgument>("ObjectArg")!.Default.Should().BeNull();
-                        cmd.Find<IArgument>("ObjectArg")!.Arity.Minimum.Should().Be(1);
+                        cmd.Find<IArgument>("ObjectArg")!.Arity.Minimum.Should().Be(0);
                         cmd.Find<IArgument>("StringListArg")!.Default.Should().BeNull();
-                        cmd.Find<IArgument>("StringListArg")!.Arity.Minimum.Should().Be(1);
+                        cmd.Find<IArgument>("StringListArg")!.Arity.Minimum.Should().Be(0);
                     }
                 }
             });
@@ -50,10 +50,10 @@ namespace CommandDotNet.Tests.FeatureTests.Arguments
         {
             new AppRunner<OperandsNoDefaults>(BasicHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll ArgsNoDefault <BoolArg> <StringArg> <StructArg> <StructNArg> <EnumArg> <ObjectArg> <StringListArg>
+                    Output = @"Usage: testhost.dll ArgsNoDefault <BoolArg> <StringArg> <StructArg> <StructNArg> <EnumArg> [<ObjectArg> <StringListArg>]
 
 Arguments:
   BoolArg
@@ -73,10 +73,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(DetailedHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll ArgsNoDefault <BoolArg> <StringArg> <StructArg> <StructNArg> <EnumArg> <ObjectArg> <StringListArg>
+                    Output = @"Usage: testhost.dll ArgsNoDefault <BoolArg> <StringArg> <StructArg> <StructNArg> <EnumArg> [<ObjectArg> <StringListArg>]
 
 Arguments:
 
@@ -105,10 +105,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(BasicHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.StructListNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.StructListNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll StructListNoDefault <StructListArg>
+                    Output = @"Usage: testhost.dll StructListNoDefault [<StructListArg>]
 
 Arguments:
   StructListArg
@@ -122,10 +122,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(DetailedHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.StructListNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.StructListNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll StructListNoDefault <StructListArg>
+                    Output = @"Usage: testhost.dll StructListNoDefault [<StructListArg>]
 
 Arguments:
 
@@ -140,10 +140,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(BasicHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.EnumListNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.EnumListNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll EnumListNoDefault <EnumListArg>
+                    Output = @"Usage: testhost.dll EnumListNoDefault [<EnumListArg>]
 
 Arguments:
   EnumListArg
@@ -157,10 +157,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(DetailedHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.EnumListNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.EnumListNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll EnumListNoDefault <EnumListArg>
+                    Output = @"Usage: testhost.dll EnumListNoDefault [<EnumListArg>]
 
 Arguments:
 
@@ -176,10 +176,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(BasicHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ObjectListNoDefault)} -h"},
+                When = { Args = $"{nameof(OperandsNoDefaults.ObjectListNoDefault)} -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll ObjectListNoDefault <ObjectListArg>
+                    Output = @"Usage: testhost.dll ObjectListNoDefault [<ObjectListArg>]
 
 Arguments:
   ObjectListArg
@@ -193,10 +193,10 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>(DetailedHelp).Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ObjectListNoDefault)}  -h" },
+                When = { Args = $"{nameof(OperandsNoDefaults.ObjectListNoDefault)}  -h" },
                 Then =
                 {
-                    Output = @"Usage: testhost.dll ObjectListNoDefault <ObjectListArg>
+                    Output = @"Usage: testhost.dll ObjectListNoDefault [<ObjectListArg>]
 
 Arguments:
 
@@ -211,11 +211,11 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>().Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} true green 1 2 Monday http://google.com yellow orange" },
+                When = { Args = $"{nameof(OperandsNoDefaults.ArgsNoDefault)} true green 1 2 Monday http://google.com yellow orange" },
                 Then =
                 {
                     AssertContext = ctx => ctx.ParamValuesShouldBe(
-                        new OperandsNoDefaultsSampleTypesModel
+                        new NrtOperandsNoDefaultsSampleTypesModel
                         {
                             BoolArg = true,
                             StringArg = "green",
@@ -234,11 +234,11 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>().Verify(new Scenario
             {
-                When = {Args = nameof(OperandsNoDefaults.ArgsNoDefault)},
+                When = { Args = nameof(OperandsNoDefaults.ArgsNoDefault) },
                 Then =
                 {
                     AssertContext = ctx => ctx.ParamValuesShouldBe(
-                        new OperandsNoDefaultsSampleTypesModel
+                        new NrtOperandsNoDefaultsSampleTypesModel
                         {
                             StructArg = default,
                             EnumArg = default,
@@ -252,11 +252,11 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>().Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.StructListNoDefault)} 23 5 7"},
+                When = { Args = $"{nameof(OperandsNoDefaults.StructListNoDefault)} 23 5 7" },
                 Then =
                 {
                     AssertContext = ctx => ctx.ParamValuesShouldBe(
-                        new OperandsNoDefaultsStructListArgumentModel
+                        new NrtOperandsNoDefaultsStructListArgumentModel
                         {
                             StructListArg = new List<int>{23,5,7}
                         })
@@ -269,11 +269,11 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>().Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.EnumListNoDefault)} Friday Tuesday Thursday"},
+                When = { Args = $"{nameof(OperandsNoDefaults.EnumListNoDefault)} Friday Tuesday Thursday" },
                 Then =
                 {
                     AssertContext = ctx => ctx.ParamValuesShouldBe(
-                        new OperandsNoDefaultsEnumListArgumentModel
+                        new NrtOperandsNoDefaultsEnumListArgumentModel
                         {
                             EnumListArg = new List<DayOfWeek>{DayOfWeek.Friday, DayOfWeek.Tuesday, DayOfWeek.Thursday}
                         })
@@ -286,11 +286,11 @@ Arguments:
         {
             new AppRunner<OperandsNoDefaults>().Verify(new Scenario
             {
-                When = {Args = $"{nameof(OperandsNoDefaults.ObjectListNoDefault)} http://google.com http://apple.com http://github.com"},
+                When = { Args = $"{nameof(OperandsNoDefaults.ObjectListNoDefault)} http://google.com http://apple.com http://github.com" },
                 Then =
                 {
                     AssertContext = ctx => ctx.ParamValuesShouldBe(
-                        new OperandsNoDefaultsObjectListArgumentModel
+                        new NrtOperandsNoDefaultsObjectListArgumentModel
                         {
                             ObjectListArg = new List<Uri>
                             {
@@ -305,35 +305,19 @@ Arguments:
 
         private class OperandsNoDefaults
         {
-            public void ArgsNoDefault(OperandsNoDefaultsSampleTypesModel model)
+            public void ArgsNoDefault(NrtOperandsNoDefaultsSampleTypesModel model)
             {
             }
 
-            public void NrtArgsNoDefault(NrtOperandsNoDefaultsSampleTypesModel model)
+            public void StructListNoDefault(NrtOperandsNoDefaultsStructListArgumentModel model)
             {
             }
 
-            public void StructListNoDefault(OperandsNoDefaultsStructListArgumentModel model)
+            public void EnumListNoDefault(NrtOperandsNoDefaultsEnumListArgumentModel model)
             {
             }
 
-            public void NrtStructListNoDefault(NrtOperandsNoDefaultsStructListArgumentModel model)
-            {
-            }
-
-            public void EnumListNoDefault(OperandsNoDefaultsEnumListArgumentModel model)
-            {
-            }
-
-            public void NrtEnumListNoDefault(NrtOperandsNoDefaultsEnumListArgumentModel model)
-            {
-            }
-
-            public void ObjectListNoDefault(OperandsNoDefaultsObjectListArgumentModel model)
-            {
-            }
-
-            public void NrtObjectListNoDefault(NrtOperandsNoDefaultsObjectListArgumentModel model)
+            public void ObjectListNoDefault(NrtOperandsNoDefaultsObjectListArgumentModel model)
             {
             }
         }

--- a/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using CommandDotNet.Prompts;
 using CommandDotNet.Tests.Utils;
 using CommandDotNet.TestTools.Prompts;
@@ -167,44 +166,6 @@ simple
                     {
                         AssertContext = ctx => ctx.ParamValuesShouldBe(
                             new List<string>{"something", "simple", "'or not'", "\"so simple\""}),
-                    }
-                });
-        }
-
-        [Fact]
-        public void WhenInterceptorOptionMissing_Prompts()
-        {
-            new AppRunner<HierApp>()
-                .UseArgumentPrompter()
-                .Verify(new Scenario
-                {
-                    When =
-                    {
-                        Args = $"{nameof(HierApp.Do)} --inherited1 2",
-                        OnPrompt = Respond.WithText("1", prompt => prompt.StartsWith("intercept1"))
-                    },
-                    Then =
-                    {
-                        AssertContext = ctx => ctx.ParamValuesShouldBe<HierApp>(1, 2)
-                    }
-                });
-        }
-
-        [Fact]
-        public void WhenInheritedOptionMissing_Prompts()
-        {
-            new AppRunner<HierApp>()
-                .UseArgumentPrompter()
-                .Verify(new Scenario
-                {
-                    When =
-                    {
-                        Args = $" --intercept1 1 {nameof(HierApp.Do)}",
-                        OnPrompt = Respond.WithText("2", prompt => prompt.StartsWith("inherited1"))
-                    },
-                    Then =
-                    {
-                        AssertContext = ctx => ctx.ParamValuesShouldBe<HierApp>(1, 2)
                     }
                 });
         }
@@ -399,20 +360,6 @@ lala (Text): fishies
             }
 
             public void Bool(bool operand1)
-            {
-            }
-        }
-
-        class HierApp
-        {
-            public Task<int> Intercept(InterceptorExecutionDelegate next, 
-                int intercept1, 
-                [Option(AssignToExecutableSubcommands = true)] int inherited1)
-            {
-                return next();
-            }
-
-            public void Do()
             {
             }
         }

--- a/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_Hierarchy.cs
+++ b/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_Hierarchy.cs
@@ -1,0 +1,72 @@
+﻿using System.Threading.Tasks;
+using CommandDotNet.Tests.Utils;
+using CommandDotNet.TestTools.Prompts;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Prompting
+{
+    public class PromptForMissingArgumentTests_Hierarchy
+    {
+        // Adapted in SpectreArgumentPrompterTests.
+        // When expectations change here, update above too
+
+        public PromptForMissingArgumentTests_Hierarchy(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [Fact]
+        public void WhenInterceptorOptionMissing_Prompts()
+        {
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)} --inherited1 2",
+                        OnPrompt = Respond.WithText("1", prompt => prompt.StartsWith("intercept1"))
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe<App>(1, 2)
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenInheritedOptionMissing_Prompts()
+        {
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $" --intercept1 1 {nameof(App.Do)}",
+                        OnPrompt = Respond.WithText("2", prompt => prompt.StartsWith("inherited1"))
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe<App>(1, 2)
+                    }
+                });
+        }
+
+        class App
+        {
+            public Task<int> Intercept(InterceptorExecutionDelegate next, 
+                int intercept1, 
+                [Option(AssignToExecutableSubcommands = true)] int inherited1)
+            {
+                return next();
+            }
+
+            public void Do()
+            {
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_NRT.cs
+++ b/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_NRT.cs
@@ -1,0 +1,69 @@
+﻿using CommandDotNet.Tests.Utils;
+using CommandDotNet.TestTools.Prompts;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Prompting
+{
+    public class PromptForMissingArgumentTests_NRT
+    {
+        public PromptForMissingArgumentTests_NRT(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [Fact]
+        public void When_OptionAndOperand_Missing_DoesNotPrompt_For_NRT_Parameters()
+        {
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)}",
+                        OnPrompt = Respond.FailOnPrompt()
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(null,null)
+                    }
+                });
+        }
+
+        [Fact]
+        public void When_OptionAndOperand_Missing_DoesNotPrompt_For_NRT_Properties()
+        {
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Props)}",
+                        OnPrompt = Respond.FailOnPrompt()
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(new App.Model{Opt1 = null,Arg1 = null})
+                    }
+                });
+        }
+
+        private class App
+        {
+            public void Do([Option] string? opt1, string? arg1){}
+
+            public void Props(Model model){}
+
+            public class Model : IArgumentModel
+            {
+                [Option]
+                public string? Opt1 { get; set; }
+                [Operand]
+                public string? Arg1 { get; set; }
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_Optional.cs
+++ b/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_Optional.cs
@@ -1,0 +1,40 @@
+﻿using CommandDotNet.Tests.Utils;
+using CommandDotNet.TestTools.Prompts;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Prompting
+{
+    public class PromptForMissingArgumentTests_Optional
+    {
+        public PromptForMissingArgumentTests_Optional(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [Fact]
+        public void When_OptionAndOperand_Missing_DoesNotPrompt_For_Optional_Parameters()
+        {
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Do)}",
+                        OnPrompt = Respond.FailOnPrompt()
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe(null,null)
+                    }
+                });
+        }
+
+        private class App
+        {
+            public void Do([Option] string? opt1 = null, string? arg1 = null){}
+        }
+    }
+}

--- a/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_Password.cs
+++ b/CommandDotNet.Tests/FeatureTests/Prompting/PromptForMissingArgumentTests_Password.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CommandDotNet.Prompts;
+using CommandDotNet.Tests.Utils;
+using CommandDotNet.TestTools.Prompts;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.Tests.FeatureTests.Prompting
+{
+    public class PromptForMissingArgumentTests_Password
+    {
+        // Adapted in SpectreArgumentPrompterTests.
+        // When expectations change here, update above too
+
+        public PromptForMissingArgumentTests_Password(ITestOutputHelper output)
+        {
+            Ambient.Output = output;
+        }
+
+        [Fact]
+        public void WhenPasswordMissing_PromptMasksInput()
+        {
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Secure)}",
+                        OnPrompt = Respond.With(
+                            new TextAnswer("lala", prompt => prompt.StartsWith("user")),
+                            new TextAnswer("fishies", prompt => prompt.StartsWith("password")))
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("lala", new Password("fishies")),
+                        Output = @"user (Text): lala
+password (Text): 
+"
+                    }
+                });
+        }
+
+        [Fact]
+        public void WhenPasswordMissing_BackspaceDoesNotRemovePromptText()
+        {
+            // \b is Console for Backspace
+
+            new AppRunner<App>()
+                .UseArgumentPrompter()
+                .Verify(new Scenario
+                {
+                    When =
+                    {
+                        Args = $"{nameof(App.Secure)}",
+                        OnPrompt = Respond.With(
+                            new TextAnswer("lala", prompt => prompt.StartsWith("user")),
+                            new TextAnswer("fishies\b\b\b\b\b\b\bnew", prompt => prompt.StartsWith("password")))
+                    },
+                    Then =
+                    {
+                        AssertContext = ctx => ctx.ParamValuesShouldBe("lala", new Password("new")),
+                        Output = @"user (Text): lala
+password (Text): 
+"
+                    }
+                });
+        }
+
+        class App
+        {
+            public void Secure(string user, Password password)
+            {
+            }
+        }
+    }
+}

--- a/CommandDotNet.Tests/UnitTests/ArgumentArityExtensionTests.cs
+++ b/CommandDotNet.Tests/UnitTests/ArgumentArityExtensionTests.cs
@@ -57,7 +57,7 @@ namespace CommandDotNet.Tests.UnitTests
         [InlineData(1, int.MaxValue, false)]
         public void AllowsNone(int min, int max, bool expected)
         {
-            new ArgumentArity(min, max).AllowsNone().Should().Be(expected);
+            new ArgumentArity(min, max).RequiresNone().Should().Be(expected);
         }
     }
 }

--- a/CommandDotNet.Tests/UnitTests/ArgumentArityTests.cs
+++ b/CommandDotNet.Tests/UnitTests/ArgumentArityTests.cs
@@ -7,56 +7,74 @@ namespace CommandDotNet.Tests.UnitTests
 {
     public class ArgumentArityTests
     {
-        private const bool NoDefault = false;
+        private const bool IsOptional = true;
         private const bool HasDefault = true;
         
         [Theory]
-        [InlineData(typeof(string), NoDefault, 1, 1)]
-        [InlineData(typeof(string), HasDefault, 0, 1)]
-        [InlineData(typeof(int), NoDefault, 1, 1)]
-        [InlineData(typeof(int), HasDefault, 0, 1)]
-        [InlineData(typeof(int?), NoDefault, 0, 1)]
-        [InlineData(typeof(int?), HasDefault, 0, 1)]
-        [InlineData(typeof(object), NoDefault, 1, 1)]
-        [InlineData(typeof(object), HasDefault, 0, 1)]
-        [InlineData(typeof(IEnumerable), NoDefault, 1, int.MaxValue)]
-        [InlineData(typeof(IEnumerable), HasDefault, 0, int.MaxValue)]
-        public void Default(Type type, bool hasDefaultValue, int expectedMin, int expectedMax)
+        [InlineData(typeof(string), IsOptional, !HasDefault, 0, 1)]
+        [InlineData(typeof(string), IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(string), !IsOptional, !HasDefault, 1, 1)]
+        [InlineData(typeof(string), !IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(int), IsOptional, !HasDefault, 0, 1)]
+        [InlineData(typeof(int), IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(int), !IsOptional, !HasDefault, 1, 1)]
+        [InlineData(typeof(int), !IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(int?), IsOptional, !HasDefault, 0, 1)]
+        [InlineData(typeof(int?), IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(int?), !IsOptional, !HasDefault, 1, 1)]
+        [InlineData(typeof(int?), !IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(object), IsOptional, !HasDefault, 0, 1)]
+        [InlineData(typeof(object), IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(object), !IsOptional, !HasDefault, 1, 1)]
+        [InlineData(typeof(object), !IsOptional, HasDefault, 0, 1)]
+        [InlineData(typeof(IEnumerable), IsOptional, !HasDefault, 0, int.MaxValue)]
+        [InlineData(typeof(IEnumerable), IsOptional, HasDefault, 0, int.MaxValue)]
+        [InlineData(typeof(IEnumerable), !IsOptional, !HasDefault, 1, int.MaxValue)]
+        [InlineData(typeof(IEnumerable), !IsOptional, HasDefault, 0, int.MaxValue)]
+        public void Default(Type type, bool isOptional, bool hasDefault, int expectedMin, int expectedMax)
         {
-            var actual = ArgumentArity.Default(type, hasDefaultValue, BooleanMode.Explicit);
+            var actual = ArgumentArity.Default(type, isOptional, hasDefault, BooleanMode.Explicit);
             var expected = new ArgumentArity(expectedMin, expectedMax);
-            expected.Should().Be(actual);
+            actual.Should().Be(expected);
         }
 
         [Theory]
-        [InlineData(BooleanMode.Explicit, NoDefault, 1, 1)]
-        [InlineData(BooleanMode.Explicit, HasDefault, 0, 1)]
-        [InlineData(BooleanMode.Implicit, NoDefault, 0, 0)]
-        [InlineData(BooleanMode.Implicit, HasDefault, 0, 0)]
-        public void DefaultBool(BooleanMode booleanMode, bool hasDefaultValue, int expectedMin, int expectedMax)
+        [InlineData(BooleanMode.Explicit, IsOptional, !HasDefault, 0, 1)]
+        [InlineData(BooleanMode.Explicit, IsOptional, HasDefault, 0, 1)]
+        [InlineData(BooleanMode.Explicit, !IsOptional, !HasDefault, 1, 1)]
+        [InlineData(BooleanMode.Explicit, !IsOptional, HasDefault, 0, 1)]
+        [InlineData(BooleanMode.Implicit, IsOptional, !HasDefault, 0, 0)]
+        [InlineData(BooleanMode.Implicit, IsOptional, HasDefault, 0, 0)]
+        [InlineData(BooleanMode.Implicit, !IsOptional, !HasDefault, 0, 0)]
+        [InlineData(BooleanMode.Implicit, !IsOptional, HasDefault, 0, 0)]
+        public void DefaultBool(BooleanMode booleanMode, bool isOptional, bool hasDefault, int expectedMin, int expectedMax)
         {
-            var actual = ArgumentArity.Default(typeof(bool), hasDefaultValue, booleanMode);
+            var actual = ArgumentArity.Default(typeof(bool), isOptional, hasDefault, booleanMode);
             var expected = new ArgumentArity(expectedMin, expectedMax);
-            expected.Should().Be(actual);
+            actual.Should().Be(expected);
         }
 
         [Theory]
-        [InlineData(BooleanMode.Explicit, NoDefault, 0 , 1)]
-        [InlineData(BooleanMode.Explicit, HasDefault, 0, 1)]
-        [InlineData(BooleanMode.Implicit, NoDefault, 0, 0)]
-        [InlineData(BooleanMode.Implicit, HasDefault, 0, 0)]
-        public void DefaultNullableBool(BooleanMode booleanMode, bool hasDefaultValue, int expectedMin, int expectedMax)
+        [InlineData(BooleanMode.Explicit, IsOptional, !HasDefault, 0, 1)]
+        [InlineData(BooleanMode.Explicit, IsOptional, HasDefault, 0, 1)]
+        [InlineData(BooleanMode.Explicit, !IsOptional, !HasDefault, 1, 1)]
+        [InlineData(BooleanMode.Explicit, !IsOptional, HasDefault, 0, 1)]
+        [InlineData(BooleanMode.Implicit, IsOptional, !HasDefault, 0, 0)]
+        [InlineData(BooleanMode.Implicit, IsOptional, HasDefault, 0, 0)]
+        [InlineData(BooleanMode.Implicit, !IsOptional, !HasDefault, 0, 0)]
+        [InlineData(BooleanMode.Implicit, !IsOptional, HasDefault, 0, 0)]
+        public void DefaultNullableBool(BooleanMode booleanMode, bool isOptional, bool hasDefault, int expectedMin, int expectedMax)
         {
-            var actual = ArgumentArity.Default(typeof(bool?), hasDefaultValue, booleanMode);
+            var actual = ArgumentArity.Default(typeof(bool?), isOptional, hasDefault, booleanMode);
             var expected = new ArgumentArity(expectedMin, expectedMax);
-            expected.Should().Be(actual);
+            actual.Should().Be(expected);
         }
 
         [Fact]
         public void DefaultBooleanModeCannotBeUnknown()
         {
             Assert.Throws<ArgumentException>(
-                    () => ArgumentArity.Default(typeof(bool), NoDefault, BooleanMode.Unknown))
+                    () => ArgumentArity.Default(typeof(bool), false, !HasDefault, BooleanMode.Unknown))
                 .Message.Should().Be("booleanMode cannot be Unknown");
         }
     }

--- a/CommandDotNet/AppSettings.cs
+++ b/CommandDotNet/AppSettings.cs
@@ -40,9 +40,9 @@ namespace CommandDotNet
         public ArgumentSeparatorStrategy DefaultArgumentSeparatorStrategy { get; set; } = ArgumentSeparatorStrategy.EndOfOptions;
 
         /// <summary>
-        /// When arguments are not decorated with [Operand] or [Option]
-        /// DefaultArgumentMode is used to determine which mode to use.
-        /// Operand is the default.
+        /// When arguments are not decorated with <see cref="OperandAttribute"/> or <see cref="OptionAttribute"/>
+        /// DefaultArgumentMode is used to determine which type of argument to assign.
+        /// <see cref="Operand"/> is the default.
         /// </summary>
         public ArgumentMode DefaultArgumentMode { get; set; } = ArgumentMode.Operand;
 

--- a/CommandDotNet/ArgumentArity.cs
+++ b/CommandDotNet/ArgumentArity.cs
@@ -44,20 +44,23 @@ namespace CommandDotNet
 
         public static IArgumentArity OneOrMore => new ArgumentArity(1, Unlimited);
 
-        internal static IArgumentArity Default(IArgumentDef argument)
+        internal static IArgumentArity Default(IArgumentDef argumentDef)
         {
-            var type = argument.Type;
-            var defaultValue = argument.DefaultValue;
-            var hasDefaultValue = !defaultValue.IsNullValue() && !defaultValue.IsDefaultFor(type);
-            return Default(type, argument.IsOptional, hasDefaultValue, argument.BooleanMode);
+            var type = argumentDef.Type;
+            var defaultValue = argumentDef.DefaultValue;
+            var hasDefaultValue = !defaultValue.IsNullValue() && !defaultValue!.IsDefaultFor(type);
+            return Default(type, argumentDef.IsOptional, hasDefaultValue, argumentDef.BooleanMode);
         }
 
         public static IArgumentArity Default(IArgument argument)
         {
             var type = argument.TypeInfo.Type;
             var defaultValue = argument.Default?.Value;
-            var hasDefaultValue = !defaultValue.IsNullValue() && !defaultValue.IsDefaultFor(type);
-            return Default(type, argument.IsOptional, hasDefaultValue, argument.BooleanMode);
+            var hasDefaultValue = !defaultValue.IsNullValue() && !defaultValue!.IsDefaultFor(type);
+            var isOptional = argument.Services.GetOrDefault<IArgumentDef>()?.IsOptional 
+                             ?? argument.Arity?.AllowsNone()
+                             ?? false;
+            return Default(type, isOptional, hasDefaultValue, argument.BooleanMode);
         }
         
         [Obsolete("Use other Default method instead. This method does not account for NRTs.")]

--- a/CommandDotNet/ArgumentArity.cs
+++ b/CommandDotNet/ArgumentArity.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CommandDotNet.ClassModeling.Definitions;
 using CommandDotNet.Extensions;
 
 namespace CommandDotNet
@@ -43,25 +44,36 @@ namespace CommandDotNet
 
         public static IArgumentArity OneOrMore => new ArgumentArity(1, Unlimited);
 
-        [Obsolete("Use other Default method instead. This method is not reliable for bool values")]
+        internal static IArgumentArity Default(IArgumentDef argument)
+        {
+            var type = argument.Type;
+            var defaultValue = argument.DefaultValue;
+            var hasDefaultValue = !defaultValue.IsNullValue() && !defaultValue.IsDefaultFor(type);
+            return Default(type, argument.IsOptional, hasDefaultValue, argument.BooleanMode);
+        }
+
         public static IArgumentArity Default(IArgument argument)
         {
             var type = argument.TypeInfo.Type;
             var defaultValue = argument.Default?.Value;
-            var hasDefaultValue = defaultValue != null && !defaultValue.IsDefaultFor(type);
-            var booleanMode = argument.Services.GetOrAdd(() => new Box<BooleanMode>(BooleanMode.Unknown)).Value;
-            return Default(type, hasDefaultValue, booleanMode);
+            var hasDefaultValue = !defaultValue.IsNullValue() && !defaultValue.IsDefaultFor(type);
+            return Default(type, argument.IsOptional, hasDefaultValue, argument.BooleanMode);
         }
+        
+        [Obsolete("Use other Default method instead. This method does not account for NRTs.")]
+        public static IArgumentArity Default(Type type, bool hasDefaultValue, BooleanMode booleanMode) =>
+            Default(type, false, hasDefaultValue, booleanMode);
 
         /// <summary>Returns the default IArgumentArity for the given type</summary>
-        public static IArgumentArity Default(Type type, bool hasDefaultValue, BooleanMode booleanMode)
+        /// <remarks>internal for tests</remarks>
+        internal static IArgumentArity Default(Type type, bool isOptional, bool hasDefaultValue, BooleanMode? booleanMode)
         {
             if (type == typeof(bool) && booleanMode == BooleanMode.Unknown)
             {
                 throw new ArgumentException($"{nameof(booleanMode)} cannot be {nameof(BooleanMode.Unknown)}");
             }
 
-            bool isRequired = !(hasDefaultValue || type.IsNullableType());
+            bool isRequired = !(isOptional || hasDefaultValue);
 
             if (type != typeof(string) && type.IsEnumerable())
             {

--- a/CommandDotNet/ArgumentArityExtensions.cs
+++ b/CommandDotNet/ArgumentArityExtensions.cs
@@ -11,7 +11,16 @@
         /// <summary><see cref="IArgumentArity.Minimum"/> == 1 == <see cref="IArgumentArity.Maximum"/></summary>
         public static bool RequiresExactlyOne(this IArgumentArity arity) => arity.Minimum == 1 && arity.Maximum == 1;
 
-        /// <summary><see cref="IArgumentArity.Maximum"/> == 0</summary>
-        public static bool AllowsNone(this IArgumentArity arity) => arity.Maximum == 0;
+        /// <summary>
+        /// <see cref="IArgumentArity.Maximum"/> == 0.
+        /// e.g. <see cref="ArgumentArity.Zero"/>
+        /// </summary>
+        public static bool RequiresNone(this IArgumentArity arity) => arity.Maximum == 0;
+
+        /// <summary>
+        /// <see cref="IArgumentArity.Minimum"/> == 0.
+        /// e.g. <see cref="ArgumentArity.Zero"/>, <see cref="ArgumentArity.ZeroOrOne"/>, <see cref="ArgumentArity.ZeroOrMore"/>
+        /// </summary>
+        public static bool AllowsNone(this IArgumentArity arity) => arity.Minimum == 0;
     }
 }

--- a/CommandDotNet/ArgumentMode.cs
+++ b/CommandDotNet/ArgumentMode.cs
@@ -2,7 +2,10 @@
 {
     public enum ArgumentMode
     {
+        /// <summary>aka: postional arguments</summary>
         Operand = 0,
+
+        /// <summary>aka: named arguments</summary>
         Option = 1
     }
 }

--- a/CommandDotNet/BooleanMode.cs
+++ b/CommandDotNet/BooleanMode.cs
@@ -2,6 +2,11 @@
 
 namespace CommandDotNet
 {
+    /// <summary>
+    /// When Explicit, boolean options require a 'true' or 'false' value be specified.<br/>
+    /// When Implicit, boolean options are treated as Flags, considered false unless it's specified
+    /// and the next argument will be considered a new argument.
+    /// </summary>
     public enum BooleanMode
     {
         [Obsolete("Use either Implicit or Explicit or Nullable<BooleanMode>")]

--- a/CommandDotNet/ClassModeling/Definitions/ClassCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/ClassCommandDef.cs
@@ -63,7 +63,8 @@ namespace CommandDotNet.ClassModeling.Definitions
             _subCommands = new Lazy<List<ICommandDef>>(() => GetSubCommands(localCommands));
         }
 
-        private (IMethodDef? interceptorMethod, ICommandDef? defaultCommand, List<ICommandDef> localCommands) ParseMethods(AppConfig appConfig)
+        private (IMethodDef? interceptorMethod, ICommandDef? defaultCommand, List<ICommandDef> localCommands) 
+            ParseMethods(AppConfig appConfig)
         {
             MethodInfo? interceptorMethodInfo = null;
             MethodInfo? defaultCommandMethodInfo = null;
@@ -109,7 +110,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             var interceptorMethod = interceptorMethodInfo == null 
                 ? null
-                : new MethodDef(interceptorMethodInfo, appConfig);
+                : new MethodDef(interceptorMethodInfo, appConfig, true);
 
             var defaultCommand = defaultCommandMethodInfo == null
                 ? null

--- a/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DefinitionMappingExtensions.cs
@@ -90,8 +90,7 @@ namespace CommandDotNet.ClassModeling.Definitions
                 return new Operand(
                     argumentDef.Name,
                     typeInfo,
-                    argumentDef.Arity, 
-                    argumentDef.IsOptional,
+                    argumentDef.Arity,
                     argumentDef.BooleanMode,
                     argumentDef.SourcePath,
                     customAttributes: argumentDef.CustomAttributes,
@@ -113,7 +112,6 @@ namespace CommandDotNet.ClassModeling.Definitions
                     ParseShortName(argumentDef, optionAttr?.ShortName),
                     typeInfo,
                     argumentDef.Arity,
-                    argumentDef.IsOptional,
                     argumentDef.BooleanMode,
                     definitionSource: argumentDef.SourcePath,
                     customAttributes: argumentDef.CustomAttributes,

--- a/CommandDotNet/ClassModeling/Definitions/DelegateCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/DelegateCommandDef.cs
@@ -26,7 +26,7 @@ namespace CommandDotNet.ClassModeling.Definitions
             _delegate = handlerDelegate;
             
             Name = name;
-            InvokeMethodDef = new MethodDef(handlerDelegate.Method, appConfig);
+            InvokeMethodDef = new MethodDef(handlerDelegate.Method, appConfig, false);
         }
 
         public override string ToString()

--- a/CommandDotNet/ClassModeling/Definitions/IArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/IArgumentDef.cs
@@ -8,8 +8,10 @@ namespace CommandDotNet.ClassModeling.Definitions
         CommandNodeType CommandNodeType { get; }
         Type Type { get; }
         bool HasDefaultValue { get; }
-        object DefaultValue { get; }
-        IArgument? Argument { get; set; }
+        object? DefaultValue { get; }
         ValueProxy ValueProxy { get; }
+        bool IsOptional { get; }
+        BooleanMode? BooleanMode { get; }
+        IArgumentArity Arity { get; }
     }
 }

--- a/CommandDotNet/ClassModeling/Definitions/MethodCommandDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/MethodCommandDef.cs
@@ -26,7 +26,7 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             Name = method.BuildName(CommandNodeType.Command, appConfig);
             CommandHostClassType = commandHostClassType;
-            InvokeMethodDef = new MethodDef(method, appConfig);
+            InvokeMethodDef = new MethodDef(method, appConfig, false);
         }
 
         public override string ToString()

--- a/CommandDotNet/ClassModeling/Definitions/ParameterArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/ParameterArgumentDef.cs
@@ -22,21 +22,14 @@ namespace CommandDotNet.ClassModeling.Definitions
 
         public bool HasDefaultValue => _parameterInfo.HasDefaultValue;
 
-        public object DefaultValue => _parameterInfo.DefaultValue;
-
-        public IArgument? Argument
-        {
-            get => _argument;
-            set
-            {
-                _argument = value;
-                value?.Services.AddOrUpdate(_parameterInfo);
-            }
-        }
+        public object? DefaultValue => _parameterInfo.DefaultValue;
 
         public ICustomAttributeProvider CustomAttributes => _parameterInfo;
 
         public ValueProxy ValueProxy { get; }
+        public bool IsOptional { get; }
+        public BooleanMode? BooleanMode { get; }
+        public IArgumentArity Arity { get; }
 
         public ParameterArgumentDef(
             ParameterInfo parameterInfo,
@@ -51,14 +44,19 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             _parameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
             CommandNodeType = commandNodeType;
-
             Name = parameterInfo.BuildName(commandNodeType, appConfig);
 
+            IsOptional = _parameterInfo.IsOptional
+                         || _parameterInfo.ParameterType.IsNullableType()
+                         || parameterInfo.GetNullability() == NullabilityState.Nullable;
+
+            BooleanMode = this.GetBooleanMode(appConfig.AppSettings.BooleanMode);
             ValueProxy = new ValueProxy(
                 () => parameterValues[parameterInfo.Position],
 
                 value => parameterValues[parameterInfo.Position] = value
             );
+            Arity = ArgumentArity.Default(this);
         }
 
         public override string ToString()

--- a/CommandDotNet/ClassModeling/Definitions/PropertyArgumentDef.cs
+++ b/CommandDotNet/ClassModeling/Definitions/PropertyArgumentDef.cs
@@ -22,21 +22,15 @@ namespace CommandDotNet.ClassModeling.Definitions
 
         public bool HasDefaultValue { get; }
 
-        public object DefaultValue { get; }
-
-        public IArgument? Argument
-        {
-            get => _argument;
-            set
-            {
-                _argument = value;
-                value?.Services.AddOrUpdate(_propertyInfo);
-            }
-        }
+        public object? DefaultValue { get; }
 
         public ICustomAttributeProvider CustomAttributes => _propertyInfo;
 
         public ValueProxy ValueProxy { get; }
+
+        public bool IsOptional { get; }
+        public BooleanMode? BooleanMode { get; }
+        public IArgumentArity Arity { get; }
 
         public PropertyArgumentDef(
             PropertyInfo propertyInfo,
@@ -53,6 +47,9 @@ namespace CommandDotNet.ClassModeling.Definitions
 
             CommandNodeType = commandNodeType;
             Name = propertyInfo.BuildName(commandNodeType, appConfig);
+            IsOptional = propertyInfo.PropertyType.IsNullableType()
+                         || propertyInfo.GetNullability() == NullabilityState.Nullable;
+            BooleanMode = this.GetBooleanMode(appConfig.AppSettings.BooleanMode);
             ValueProxy = new ValueProxy(
                 () => _propertyInfo.GetValue(modelInstance),
 
@@ -62,6 +59,7 @@ namespace CommandDotNet.ClassModeling.Definitions
             HasDefaultValue = propertyInfo.PropertyType.IsClass
                 ? !DefaultValue.IsNullValue()
                 : !DefaultValue.IsDefaultFor(propertyInfo.PropertyType);
+            Arity = ArgumentArity.Default(this);
         }
 
         public override string ToString()

--- a/CommandDotNet/Diagnostics/Parse/ParseReporter.cs
+++ b/CommandDotNet/Diagnostics/Parse/ParseReporter.cs
@@ -70,7 +70,7 @@ namespace CommandDotNet.Diagnostics.Parse
             var txtDefault = Resources.A.Common_default_lc;
 
             var displayName = argument.TypeInfo.DisplayName.IsNullOrEmpty() 
-                ? (argument.Arity.AllowsNone() ? Resources.A.Common_Flag : null)
+                ? (argument.Arity.RequiresNone() ? Resources.A.Common_Flag : null)
                 : argument.TypeInfo.DisplayName;
             writeln($"{indent}{argument.Name} <{displayName}>");
             var valueString = argument.Value?.ValueToString(argument);

--- a/CommandDotNet/Diagnostics/VersionMiddleware.cs
+++ b/CommandDotNet/Diagnostics/VersionMiddleware.cs
@@ -31,7 +31,7 @@ namespace CommandDotNet.Diagnostics
             }
 
             var option = new Option(VersionOptionName, 'v', 
-                TypeInfo.Flag, ArgumentArity.Zero, 
+                TypeInfo.Flag, ArgumentArity.Zero, BooleanMode.Implicit,
                 definitionSource: typeof(VersionMiddleware).FullName)
             {
                 Description = Resources.A.Command_version_description,

--- a/CommandDotNet/Execution/IInvocation.cs
+++ b/CommandDotNet/Execution/IInvocation.cs
@@ -34,6 +34,9 @@ namespace CommandDotNet.Execution
         /// </remarks>
         MethodInfo MethodInfo { get; }
 
+        /// <summary>The invocation is for an interceptor method, not a command</summary>
+        public bool IsInterceptor { get; }
+
         /// <summary>
         /// All <see cref="IArgumentModel"/>s for the invocation,
         /// flattened so you do not need to reflect properties to

--- a/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfo.cs
+++ b/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfo.cs
@@ -1,0 +1,65 @@
+#nullable enable
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.ObjectModel;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// A class that represents nullability info
+    /// </summary>
+    sealed class NullabilityInfo
+    {
+        internal NullabilityInfo(Type type, NullabilityState readState, NullabilityState writeState,
+            NullabilityInfo? elementType, NullabilityInfo[] typeArguments)
+        {
+            Type = type;
+            ReadState = readState;
+            WriteState = writeState;
+            ElementType = elementType;
+            GenericTypeArguments = typeArguments;
+        }
+
+        /// <summary>
+        /// The <see cref="System.Type" /> of the member or generic parameter
+        /// to which this NullabilityInfo belongs
+        /// </summary>
+        public Type Type { get; }
+        /// <summary>
+        /// The nullability read state of the member
+        /// </summary>
+        public NullabilityState ReadState { get; internal set; }
+        /// <summary>
+        /// The nullability write state of the member
+        /// </summary>
+        public NullabilityState WriteState { get; internal set; }
+        /// <summary>
+        /// If the member type is an array, gives the <see cref="NullabilityInfo" /> of the elements of the array, null otherwise
+        /// </summary>
+        public NullabilityInfo? ElementType { get; }
+        /// <summary>
+        /// If the member type is a generic type, gives the array of <see cref="NullabilityInfo" /> for each type parameter
+        /// </summary>
+        public NullabilityInfo[] GenericTypeArguments { get; }
+    }
+
+    /// <summary>
+    /// An enum that represents nullability state
+    /// </summary>
+    enum NullabilityState
+    {
+        /// <summary>
+        /// Nullability context not enabled (oblivious)
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Non nullable value or reference type
+        /// </summary>
+        NotNull,
+        /// <summary>
+        /// Nullable value or reference type
+        /// </summary>
+        Nullable
+    }
+}

--- a/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfo.md
+++ b/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfo.md
@@ -1,0 +1,4 @@
+﻿copied from https://github.com/SimonCropp/NullabilityInfo
+
+waiting for https://github.com/SimonCropp/NullabilityInfo/pull/6
+to use nuget instead.

--- a/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfoContext.cs
+++ b/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfoContext.cs
@@ -1,0 +1,546 @@
+#nullable enable
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Provides APIs for populating nullability information/context from reflection members:
+    /// <see cref="ParameterInfo"/>, <see cref="FieldInfo"/>, <see cref="PropertyInfo"/> and <see cref="EventInfo"/>.
+    /// </summary>
+    sealed class NullabilityInfoContext
+    {
+        private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
+        private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = new Dictionary<Module, NotAnnotatedStatus>();
+        private readonly Dictionary<MemberInfo, NullabilityState> _context = new Dictionary<MemberInfo, NullabilityState>();
+
+        internal static bool IsSupported { get; } =
+            AppContext.TryGetSwitch("System.Reflection.NullabilityInfoContext.IsSupported", out bool isSupported) ? isSupported : true;
+
+        [Flags]
+        private enum NotAnnotatedStatus
+        {
+            None = 0x0,    // no restriction, all members annotated
+            Private = 0x1, // private members not annotated
+            Internal = 0x2 // internal members not annotated
+        }
+
+        private NullabilityState GetNullableContext(MemberInfo? memberInfo)
+        {
+            while (memberInfo != null)
+            {
+                if (_context.TryGetValue(memberInfo, out NullabilityState state))
+                {
+                    return state;
+                }
+
+                foreach (CustomAttributeData attribute in memberInfo.GetCustomAttributesData())
+                {
+                    if (attribute.AttributeType.Name == "NullableContextAttribute" &&
+                        attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                        attribute.ConstructorArguments.Count == 1)
+                    {
+                        state = TranslateByte(attribute.ConstructorArguments[0].Value);
+                        _context.Add(memberInfo, state);
+                        return state;
+                    }
+                }
+
+                memberInfo = memberInfo.DeclaringType;
+            }
+
+            return NullabilityState.Unknown;
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="ParameterInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="parameterInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the parameterInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(ParameterInfo parameterInfo)
+        {
+            if (parameterInfo is null)
+            {
+                throw new ArgumentNullException(nameof(parameterInfo));
+            }
+
+            EnsureIsSupported();
+
+            if (parameterInfo.Member is MethodInfo method && IsPrivateOrInternalMethodAndAnnotationDisabled(method))
+            {
+                return new NullabilityInfo(parameterInfo.ParameterType, NullabilityState.Unknown, NullabilityState.Unknown, null, Array.Empty<NullabilityInfo>());
+            }
+
+            IList<CustomAttributeData> attributes = parameterInfo.GetCustomAttributesData();
+            NullabilityInfo nullability = GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, attributes);
+
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                CheckParameterMetadataType(parameterInfo, nullability);
+            }
+
+            CheckNullabilityAttributes(nullability, attributes);
+            return nullability;
+        }
+
+        private void CheckParameterMetadataType(ParameterInfo parameter, NullabilityInfo nullability)
+        {
+            if (parameter.Member is MethodInfo method)
+            {
+                MethodInfo metaMethod = GetMethodMetadataDefinition(method);
+                ParameterInfo? metaParameter = null;
+                if (string.IsNullOrEmpty(parameter.Name))
+                {
+                    metaParameter = metaMethod.ReturnParameter;
+                }
+                else
+                {
+                    ParameterInfo[] parameters = metaMethod.GetParameters();
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        if (parameter.Position == i &&
+                            parameter.Name == parameters[i].Name)
+                        {
+                            metaParameter = parameters[i];
+                            break;
+                        }
+                    }
+                }
+
+                if (metaParameter != null)
+                {
+                    CheckGenericParameters(nullability, metaMethod, metaParameter.ParameterType);
+                }
+            }
+        }
+
+        private static MethodInfo GetMethodMetadataDefinition(MethodInfo method)
+        {
+            if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+            {
+                method = method.GetGenericMethodDefinition();
+            }
+
+            return (MethodInfo)GetMemberMetadataDefinition(method);
+        }
+
+        private void CheckNullabilityAttributes(NullabilityInfo nullability, IList<CustomAttributeData> attributes)
+        {
+            foreach (CustomAttributeData attribute in attributes)
+            {
+                if (attribute.AttributeType.Namespace == "System.Diagnostics.CodeAnalysis")
+                {
+                    if (attribute.AttributeType.Name == "NotNullAttribute" &&
+                        nullability.ReadState == NullabilityState.Nullable)
+                    {
+                        nullability.ReadState = NullabilityState.NotNull;
+                        break;
+                    }
+                    else if ((attribute.AttributeType.Name == "MaybeNullAttribute" ||
+                            attribute.AttributeType.Name == "MaybeNullWhenAttribute") &&
+                            nullability.ReadState == NullabilityState.NotNull &&
+                            !nullability.Type.IsValueType)
+                    {
+                        nullability.ReadState = NullabilityState.Nullable;
+                        break;
+                    }
+
+                    if (attribute.AttributeType.Name == "DisallowNullAttribute" &&
+                        nullability.WriteState == NullabilityState.Nullable)
+                    {
+                        nullability.WriteState = NullabilityState.NotNull;
+                        break;
+                    }
+                    else if (attribute.AttributeType.Name == "AllowNullAttribute" &&
+                        nullability.WriteState == NullabilityState.NotNull &&
+                        !nullability.Type.IsValueType)
+                    {
+                        nullability.WriteState = NullabilityState.Nullable;
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="PropertyInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="propertyInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the propertyInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo is null)
+            {
+                throw new ArgumentNullException(nameof(propertyInfo));
+            }
+
+            EnsureIsSupported();
+
+            NullabilityInfo nullability = GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, propertyInfo.GetCustomAttributesData());
+            MethodInfo? getter = propertyInfo.GetGetMethod(true);
+            MethodInfo? setter = propertyInfo.GetSetMethod(true);
+
+            if (getter != null)
+            {
+                if (IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
+                {
+                    nullability.ReadState = NullabilityState.Unknown;
+                }
+
+                CheckNullabilityAttributes(nullability, getter.ReturnParameter.GetCustomAttributesData());
+            }
+            else
+            {
+                nullability.ReadState = NullabilityState.Unknown;
+            }
+
+            if (setter != null)
+            {
+                if (IsPrivateOrInternalMethodAndAnnotationDisabled(setter))
+                {
+                    nullability.WriteState = NullabilityState.Unknown;
+                }
+
+                CheckNullabilityAttributes(nullability, setter.GetParameters()[0].GetCustomAttributesData());
+            }
+            else
+            {
+                nullability.WriteState = NullabilityState.Unknown;
+            }
+
+            return nullability;
+        }
+
+        private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodInfo method)
+        {
+            if ((method.IsPrivate || method.IsFamilyAndAssembly || method.IsAssembly) &&
+               IsPublicOnly(method.IsPrivate, method.IsFamilyAndAssembly, method.IsAssembly, method.Module))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="EventInfo" />.
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="eventInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the eventInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(EventInfo eventInfo)
+        {
+            if (eventInfo is null)
+            {
+                throw new ArgumentNullException(nameof(eventInfo));
+            }
+
+            EnsureIsSupported();
+
+            return GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, eventInfo.GetCustomAttributesData());
+        }
+
+        /// <summary>
+        /// Populates <see cref="NullabilityInfo" /> for the given <see cref="FieldInfo" />
+        /// If the nullablePublicOnly feature is set for an assembly, like it does in .NET SDK, the private and/or internal member's
+        /// nullability attributes are omitted, in this case the API will return NullabilityState.Unknown state.
+        /// </summary>
+        /// <param name="fieldInfo">The parameter which nullability info gets populated</param>
+        /// <exception cref="ArgumentNullException">If the fieldInfo parameter is null</exception>
+        /// <returns><see cref="NullabilityInfo" /></returns>
+        public NullabilityInfo Create(FieldInfo fieldInfo)
+        {
+            if (fieldInfo is null)
+            {
+                throw new ArgumentNullException(nameof(fieldInfo));
+            }
+
+            EnsureIsSupported();
+
+            if (IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo))
+            {
+                return new NullabilityInfo(fieldInfo.FieldType, NullabilityState.Unknown, NullabilityState.Unknown, null, Array.Empty<NullabilityInfo>());
+            }
+
+            IList<CustomAttributeData> attributes = fieldInfo.GetCustomAttributesData();
+            NullabilityInfo nullability = GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, attributes);
+            CheckNullabilityAttributes(nullability, attributes);
+            return nullability;
+        }
+
+        private static void EnsureIsSupported()
+        {
+            if (!IsSupported)
+            {
+                throw new InvalidOperationException(SR.NullabilityInfoContext_NotSupported);
+            }
+        }
+
+        private bool IsPrivateOrInternalFieldAndAnnotationDisabled(FieldInfo fieldInfo)
+        {
+            if ((fieldInfo.IsPrivate || fieldInfo.IsFamilyAndAssembly || fieldInfo.IsAssembly) &&
+                IsPublicOnly(fieldInfo.IsPrivate, fieldInfo.IsFamilyAndAssembly, fieldInfo.IsAssembly, fieldInfo.Module))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsPublicOnly(bool isPrivate, bool isFamilyAndAssembly, bool isAssembly, Module module)
+        {
+            if (!_publicOnlyModules.TryGetValue(module, out NotAnnotatedStatus value))
+            {
+                value = PopulateAnnotationInfo(module.GetCustomAttributesData());
+                _publicOnlyModules.Add(module, value);
+            }
+
+            if (value == NotAnnotatedStatus.None)
+            {
+                return false;
+            }
+
+            if ((isPrivate || isFamilyAndAssembly) && value.HasFlag(NotAnnotatedStatus.Private) ||
+                 isAssembly && value.HasFlag(NotAnnotatedStatus.Internal))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private NotAnnotatedStatus PopulateAnnotationInfo(IList<CustomAttributeData> customAttributes)
+        {
+            foreach (CustomAttributeData attribute in customAttributes)
+            {
+                if (attribute.AttributeType.Name == "NullablePublicOnlyAttribute" &&
+                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                    attribute.ConstructorArguments.Count == 1)
+                {
+                    if (attribute.ConstructorArguments[0].Value is bool boolValue && boolValue)
+                    {
+                        return NotAnnotatedStatus.Internal | NotAnnotatedStatus.Private;
+                    }
+                    else
+                    {
+                        return NotAnnotatedStatus.Private;
+                    }
+                }
+            }
+
+            return NotAnnotatedStatus.None;
+        }
+
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes) =>
+            GetNullabilityInfo(memberInfo, type, customAttributes, 0);
+
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes, int index)
+        {
+            NullabilityState state = NullabilityState.Unknown;
+            NullabilityInfo? elementState = null;
+            NullabilityInfo[] genericArgumentsState = Array.Empty<NullabilityInfo>();
+            Type? underlyingType = type;
+
+            if (type.IsValueType)
+            {
+                underlyingType = Nullable.GetUnderlyingType(type);
+
+                if (underlyingType != null)
+                {
+                    state = NullabilityState.Nullable;
+                }
+                else
+                {
+                    underlyingType = type;
+                    state = NullabilityState.NotNull;
+                }
+            }
+            else
+            {
+                if (!ParseNullableState(customAttributes, index, ref state))
+                {
+                    state = GetNullableContext(memberInfo);
+                }
+
+                if (type.IsArray)
+                {
+                    elementState = GetNullabilityInfo(memberInfo, type.GetElementType()!, customAttributes, index + 1);
+                }
+            }
+
+            if (underlyingType.IsGenericType)
+            {
+                Type[] genericArguments = underlyingType.GetGenericArguments();
+                genericArgumentsState = new NullabilityInfo[genericArguments.Length];
+
+                for (int i = 0, offset = 0; i < genericArguments.Length; i++)
+                {
+                    Type t = Nullable.GetUnderlyingType(genericArguments[i]) ?? genericArguments[i];
+
+                    if (!t.IsValueType || t.IsGenericType)
+                    {
+                        offset++;
+                    }
+
+                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], customAttributes, index + offset);
+                }
+            }
+
+            NullabilityInfo nullability = new NullabilityInfo(type, state, state, elementState, genericArgumentsState);
+
+            if (!type.IsValueType && state != NullabilityState.Unknown)
+            {
+                TryLoadGenericMetaTypeNullability(memberInfo, nullability);
+            }
+
+            return nullability;
+        }
+
+        private static bool ParseNullableState(IList<CustomAttributeData> customAttributes, int index, ref NullabilityState state)
+        {
+            foreach (CustomAttributeData attribute in customAttributes)
+            {
+                if (attribute.AttributeType.Name == "NullableAttribute" &&
+                    attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
+                    attribute.ConstructorArguments.Count == 1)
+                {
+                    object? o = attribute.ConstructorArguments[0].Value;
+
+                    if (o is byte b)
+                    {
+                        state = TranslateByte(b);
+                        return true;
+                    }
+                    else if (o is ReadOnlyCollection<CustomAttributeTypedArgument> args &&
+                            index < args.Count &&
+                            args[index].Value is byte elementB)
+                        {
+                            state = TranslateByte(elementB);
+                            return true;
+                        }
+
+                    break;
+                }
+            }
+
+            return false;
+        }
+
+        private void TryLoadGenericMetaTypeNullability(MemberInfo memberInfo, NullabilityInfo nullability)
+        {
+            MemberInfo? metaMember = GetMemberMetadataDefinition(memberInfo);
+            Type? metaType = null;
+            if (metaMember is FieldInfo field)
+            {
+                metaType = field.FieldType;
+            }
+            else if (metaMember is PropertyInfo property)
+            {
+                metaType = GetPropertyMetaType(property);
+            }
+
+            if (metaType != null)
+            {
+                CheckGenericParameters(nullability, metaMember!, metaType);
+            }
+        }
+
+        private static MemberInfo GetMemberMetadataDefinition(MemberInfo member)
+        {
+            Type? type = member.DeclaringType;
+            if ((type != null) && type.IsGenericType && !type.IsGenericTypeDefinition)
+            {
+                return type.GetGenericTypeDefinition().GetMemberWithSameMetadataDefinitionAs(member);
+            }
+
+            return member;
+        }
+
+        private static Type GetPropertyMetaType(PropertyInfo property)
+        {
+            if (property.GetGetMethod(true) is MethodInfo method)
+            {
+                return method.ReturnType;
+            }
+
+            return property.GetSetMethod(true)!.GetParameters()[0].ParameterType;
+        }
+
+        private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType)
+        {
+            if (metaType.IsGenericParameter)
+            {
+                NullabilityState state = nullability.ReadState;
+
+                if (state == NullabilityState.NotNull && !ParseNullableState(metaType.GetCustomAttributesData(), 0, ref state))
+                {
+                    state = GetNullableContext(metaType);
+                }
+
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+            }
+            else if (metaType.ContainsGenericParameters)
+            {
+                if (nullability.GenericTypeArguments.Length > 0)
+                {
+                    Type[] genericArguments = metaType.GetGenericArguments();
+
+                    for (int i = 0; i < genericArguments.Length; i++)
+                    {
+                        if (genericArguments[i].IsGenericParameter)
+                        {
+                            NullabilityInfo n = GetNullabilityInfo(metaMember, genericArguments[i], genericArguments[i].GetCustomAttributesData(), i + 1);
+                            nullability.GenericTypeArguments[i].ReadState = n.ReadState;
+                            nullability.GenericTypeArguments[i].WriteState = n.WriteState;
+                        }
+                        else
+                        {
+                            UpdateGenericArrayElements(nullability.GenericTypeArguments[i].ElementType, metaMember, genericArguments[i]);
+                        }
+                    }
+                }
+                else
+                {
+                    UpdateGenericArrayElements(nullability.ElementType, metaMember, metaType);
+                }
+            }
+        }
+
+        private void UpdateGenericArrayElements(NullabilityInfo? elementState, MemberInfo metaMember, Type metaType)
+        {
+            if (metaType.IsArray && elementState != null
+                && metaType.GetElementType()!.IsGenericParameter)
+            {
+                Type elementType = metaType.GetElementType()!;
+                NullabilityInfo n = GetNullabilityInfo(metaMember, elementType, elementType.GetCustomAttributesData(), 0);
+                elementState.ReadState = n.ReadState;
+                elementState.WriteState = n.WriteState;
+            }
+        }
+
+        private static NullabilityState TranslateByte(object? value)
+        {
+            return value is byte b ? TranslateByte(b) : NullabilityState.Unknown;
+        }
+
+        private static NullabilityState TranslateByte(byte b) =>
+            b switch
+            {
+                1 => NullabilityState.NotNull,
+                2 => NullabilityState.Nullable,
+                _ => NullabilityState.Unknown
+            };
+    }
+}

--- a/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfoExtensions.cs
+++ b/CommandDotNet/Extensions/NullabilityInfo/NullabilityInfoExtensions.cs
@@ -1,0 +1,160 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Static and thread safe wrapper around <see cref="NullabilityInfoContext"/>.
+    /// </summary>
+    internal static partial class NullabilityInfoExtensions
+    {
+        static ConcurrentDictionary<ParameterInfo, NullabilityInfo> parameterCache = new ConcurrentDictionary<ParameterInfo, NullabilityInfo>();
+        static ConcurrentDictionary<PropertyInfo, NullabilityInfo> propertyCache = new ConcurrentDictionary<PropertyInfo, NullabilityInfo>();
+        static ConcurrentDictionary<EventInfo, NullabilityInfo> eventCache = new ConcurrentDictionary<EventInfo, NullabilityInfo>();
+        static ConcurrentDictionary<FieldInfo, NullabilityInfo> fieldCache = new ConcurrentDictionary<FieldInfo, NullabilityInfo>();
+
+        internal static NullabilityInfo GetNullabilityInfo(this MemberInfo info)
+        {
+            if (info is PropertyInfo propertyInfo)
+            {
+                return propertyInfo.GetNullabilityInfo();
+            }
+
+            if (info is EventInfo eventInfo)
+            {
+                return eventInfo.GetNullabilityInfo();
+            }
+
+            if (info is FieldInfo fieldInfo)
+            {
+                return fieldInfo.GetNullabilityInfo();
+            }
+
+            throw new ArgumentException($"Unsuported type:{info.GetType().FullName}");
+        }
+
+        internal static NullabilityState GetNullability(this MemberInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        internal static bool IsNullable(this MemberInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        internal static NullabilityInfo GetNullabilityInfo(this FieldInfo info)
+        {
+            return fieldCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        internal static NullabilityState GetNullability(this FieldInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        internal static bool IsNullable(this FieldInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        internal static NullabilityInfo GetNullabilityInfo(this EventInfo info)
+        {
+            return eventCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        internal static NullabilityState GetNullability(this EventInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        internal static bool IsNullable(this EventInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        internal static NullabilityInfo GetNullabilityInfo(this PropertyInfo info)
+        {
+            return propertyCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        internal static NullabilityState GetNullability(this PropertyInfo info)
+        {
+            return GetReadOrWriteState(info.Name, info.GetNullabilityInfo());
+        }
+
+        internal static bool IsNullable(this PropertyInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name, nullability);
+        }
+
+        internal static NullabilityInfo GetNullabilityInfo(this ParameterInfo info)
+        {
+            return parameterCache.GetOrAdd(info, inner =>
+            {
+                var nullabilityContext = new NullabilityInfoContext();
+                return nullabilityContext.Create(inner);
+            });
+        }
+
+        internal static NullabilityState GetNullability(this ParameterInfo info)
+        {
+            return GetReadOrWriteState(info.Name!, info.GetNullabilityInfo());
+        }
+
+        internal static bool IsNullable(this ParameterInfo info)
+        {
+            var nullability = info.GetNullabilityInfo();
+            return IsNullable(info.Name!, nullability);
+        }
+
+        static NullabilityState GetReadOrWriteState(string name, NullabilityInfo nullability)
+        {
+            if (nullability.ReadState != NullabilityState.Unknown)
+            {
+                return nullability.ReadState;
+            }
+
+            return nullability.WriteState;
+        }
+
+        static NullabilityState GetKnownState(string name, NullabilityInfo nullability)
+        {
+            var readState = nullability.ReadState;
+            if (readState != NullabilityState.Unknown)
+            {
+                return readState;
+            }
+
+            var writeState = nullability.WriteState;
+            if (writeState != NullabilityState.Unknown)
+            {
+                return writeState;
+            }
+
+            throw new Exception($"The nullability of '{nullability.Type.FullName}.{name}' is unknown. Assembly: {nullability.Type.Assembly.FullName}.");
+        }
+    
+        static bool IsNullable(string name, NullabilityInfo nullability)
+        {
+            return GetKnownState(name, nullability) == NullabilityState.Nullable;
+        }
+    }
+}

--- a/CommandDotNet/Extensions/NullabilityInfo/Patching.cs
+++ b/CommandDotNet/Extensions/NullabilityInfo/Patching.cs
@@ -1,0 +1,43 @@
+#nullable enable
+
+namespace System.Reflection
+{
+    class SR
+    {
+        public static string NullabilityInfoContext_NotSupported = "NullabilityInfoContext is not supported";
+    }
+
+    internal static partial class NullabilityInfoExtensions
+    {
+        internal static MemberInfo GetMemberWithSameMetadataDefinitionAs(this Type type, MemberInfo member)
+        {
+            if (member is null) throw new ArgumentNullException(nameof(member));
+
+            const BindingFlags all = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+            foreach (MemberInfo myMemberInfo in type.GetMembers(all))
+            {
+                if (myMemberInfo.HasSameMetadataDefinitionAs(member))
+                {
+                    return myMemberInfo;
+                }
+            }
+
+            throw new MissingMemberException(type.FullName, member.Name);
+        }
+
+        //https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/MemberInfo.Internal.cs
+        static bool HasSameMetadataDefinitionAs(this MemberInfo target, MemberInfo other)
+        {
+            if (other is null)
+                throw new ArgumentNullException(nameof(other));
+
+            if (target.MetadataToken != other.MetadataToken)
+                return false;
+
+            if (!target.Module.Equals(other.Module))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/CommandDotNet/Help/HelpMiddleware.cs
+++ b/CommandDotNet/Help/HelpMiddleware.cs
@@ -27,7 +27,7 @@ namespace CommandDotNet.Help
             var appSettingsHelp = args.CommandContext.AppConfig.AppSettings.Help;
 
             var option = new Option(helpOptionName, 'h',
-                TypeInfo.Flag, ArgumentArity.Zero,
+                TypeInfo.Flag, ArgumentArity.Zero, BooleanMode.Implicit,
                 aliases: new[] { "?" },
                 definitionSource: typeof(HelpMiddleware).FullName)
             {

--- a/CommandDotNet/IArgument.cs
+++ b/CommandDotNet/IArgument.cs
@@ -13,6 +13,12 @@ namespace CommandDotNet
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         IArgumentArity Arity { get; set; }
 
+        /// <summary>When true, the argument is optional. an be true for Nullable and NRT types and optional parameters</summary>
+        bool IsOptional { get; set; }
+
+        /// <summary>The <see cref="BooleanMode"/> for this argument. This property is only set for boolean arguments.</summary>
+        BooleanMode? BooleanMode { get; set; }
+
         /// <summary>The default value for this argument</summary>
         ArgumentDefault? Default { get; set; }
 

--- a/CommandDotNet/IArgument.cs
+++ b/CommandDotNet/IArgument.cs
@@ -13,9 +13,6 @@ namespace CommandDotNet
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         IArgumentArity Arity { get; set; }
 
-        /// <summary>When true, the argument is optional. an be true for Nullable and NRT types and optional parameters</summary>
-        bool IsOptional { get; set; }
-
         /// <summary>The <see cref="BooleanMode"/> for this argument. This property is only set for boolean arguments.</summary>
         BooleanMode? BooleanMode { get; set; }
 

--- a/CommandDotNet/Operand.cs
+++ b/CommandDotNet/Operand.cs
@@ -21,6 +21,8 @@ namespace CommandDotNet
             string name,
             TypeInfo typeInfo,
             IArgumentArity arity,
+            bool isOptional = false,
+            BooleanMode? booleanMode = null,
             string? definitionSource = null,
             ICustomAttributeProvider? customAttributes = null,
             ValueProxy? valueProxy = null)
@@ -29,6 +31,8 @@ namespace CommandDotNet
             Name = name ?? throw new ArgumentNullException(nameof(name));
             TypeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             Arity = arity ?? throw new ArgumentNullException(nameof(arity));
+            IsOptional = isOptional;
+            BooleanMode = booleanMode;
             DefinitionSource = definitionSource;
             Aliases = new[] {name};
             CustomAttributes = customAttributes ?? NullCustomAttributeProvider.Instance;
@@ -42,6 +46,9 @@ namespace CommandDotNet
 
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
+
+        public bool IsOptional { get; set; }
+        public BooleanMode? BooleanMode { get; set; }
 
         /// <summary>The default value for this argument</summary>
         public ArgumentDefault? Default { get; set; }

--- a/CommandDotNet/Operand.cs
+++ b/CommandDotNet/Operand.cs
@@ -21,7 +21,6 @@ namespace CommandDotNet
             string name,
             TypeInfo typeInfo,
             IArgumentArity arity,
-            bool isOptional = false,
             BooleanMode? booleanMode = null,
             string? definitionSource = null,
             ICustomAttributeProvider? customAttributes = null,
@@ -31,7 +30,6 @@ namespace CommandDotNet
             Name = name ?? throw new ArgumentNullException(nameof(name));
             TypeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             Arity = arity ?? throw new ArgumentNullException(nameof(arity));
-            IsOptional = isOptional;
             BooleanMode = booleanMode;
             DefinitionSource = definitionSource;
             Aliases = new[] {name};
@@ -46,8 +44,7 @@ namespace CommandDotNet
 
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
-
-        public bool IsOptional { get; set; }
+        
         public BooleanMode? BooleanMode { get; set; }
 
         /// <summary>The default value for this argument</summary>

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -24,6 +24,8 @@ namespace CommandDotNet
             char? shortName,
             TypeInfo typeInfo,
             IArgumentArity arity,
+            bool isOptional = false,
+            BooleanMode? booleanMode = null,
             string? definitionSource = null,
             IEnumerable<string>? aliases = null,
             ICustomAttributeProvider? customAttributes = null,
@@ -51,6 +53,8 @@ namespace CommandDotNet
 
             TypeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             Arity = arity ?? throw new ArgumentNullException(nameof(arity));
+            IsOptional = isOptional;
+            BooleanMode = booleanMode;
             DefinitionSource = definitionSource;
             IsInterceptorOption = isInterceptorOption;
             AssignToExecutableSubcommands = assignToExecutableSubcommands;
@@ -108,6 +112,9 @@ namespace CommandDotNet
 
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
+
+        public bool IsOptional { get; set; }
+        public BooleanMode? BooleanMode { get; set; }
 
         /// <summary>The default value for this argument</summary>
         public ArgumentDefault? Default { get; set; }

--- a/CommandDotNet/Option.cs
+++ b/CommandDotNet/Option.cs
@@ -24,7 +24,6 @@ namespace CommandDotNet
             char? shortName,
             TypeInfo typeInfo,
             IArgumentArity arity,
-            bool isOptional = false,
             BooleanMode? booleanMode = null,
             string? definitionSource = null,
             IEnumerable<string>? aliases = null,
@@ -53,7 +52,6 @@ namespace CommandDotNet
 
             TypeInfo = typeInfo ?? throw new ArgumentNullException(nameof(typeInfo));
             Arity = arity ?? throw new ArgumentNullException(nameof(arity));
-            IsOptional = isOptional;
             BooleanMode = booleanMode;
             DefinitionSource = definitionSource;
             IsInterceptorOption = isInterceptorOption;
@@ -113,7 +111,6 @@ namespace CommandDotNet
         /// <summary>The <see cref="IArgumentArity"/> for this argument, describing how many values are allowed.</summary>
         public IArgumentArity Arity { get; set; }
 
-        public bool IsOptional { get; set; }
         public BooleanMode? BooleanMode { get; set; }
 
         /// <summary>The default value for this argument</summary>

--- a/CommandDotNet/Parsing/CommandParser.cs
+++ b/CommandDotNet/Parsing/CommandParser.cs
@@ -115,7 +115,7 @@ namespace CommandDotNet.Parsing
                 throw new InvalidOperationException($"Bug: SplitOptionAssignments transformation should have split values from all option tokens: {token}");
             }
 
-            if (option.Arity.AllowsNone())
+            if (option.Arity.RequiresNone())
             {
                 var values = option.GetAlreadyParsedValues();
                 // only possible for flags which are boolean type
@@ -140,7 +140,7 @@ namespace CommandDotNet.Parsing
                 {
                     AddOptionValue(parseContext, option, values, optionToken, token, token.Value);
                 }
-                else if (option.Arity.AllowsNone())
+                else if (option.Arity.RequiresNone())
                 {
                     throw new InvalidOperationException($"Bug: flag '{option.Name}' should have finished processing in {nameof(ParseOption)}");
                 }

--- a/CommandDotNet/TypeDescriptors/BoolTypeDescriptor.cs
+++ b/CommandDotNet/TypeDescriptors/BoolTypeDescriptor.cs
@@ -15,7 +15,7 @@ namespace CommandDotNet.TypeDescriptors
         
         public string GetDisplayName(IArgument argument)
         {
-            return argument.Arity.AllowsNone()
+            return argument.Arity.RequiresNone()
                 ? ""
                 : Resources.A.Type_Boolean;
         }
@@ -27,7 +27,7 @@ namespace CommandDotNet.TypeDescriptors
 
         public IEnumerable<string> GetAllowedValues(IArgument argument)
         {
-            return argument.Arity.AllowsNone()
+            return argument.Arity.RequiresNone()
                 ? Enumerable.Empty<string>()
                 : new List<string> { "true", "false" };
         }

--- a/docs/Arguments/argument-arity.md
+++ b/docs/Arguments/argument-arity.md
@@ -12,7 +12,7 @@ When...
 
   * _minimum_ == 0, no values are required 
       * this applies to flags and [optional arguments](#optional-arguments)
-  *  _maximum_ > 1, multiple values can be provided
+  * _maximum_ > 1, multiple values can be provided
   * _maximum_ == int.MaxValue, an unlimited number of values can be provided
 
 !!! note
@@ -60,7 +60,8 @@ The static method `ArgumentArity.Default(type, ...)` will return one of these st
 
 An argument is considered optional when defined as...
 
-* a Nullable<T> type  eg. bool?, Guid?
+* a Nullable<T> type: bool?, Guid?
+* a [Nullable refernce type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/nullable-reference-types) (NRT): object?
 * an optional parameter
 * an `IArgumentModel` property with a default value where the default value != default(T)
     * the value must be set in the ctor or property assignment. This condition is evaluated immediately after instantiation.
@@ -78,7 +79,7 @@ Consider there are two categories of default values
 1. Default values specified by the user to simplify use of the application. For example, pulling default values from [Environment Variables and AppSettings](../ArgumentValues/default-values-from-config.md). 
     * The application requires a value but the user does not have to enter it because it is defaulted by a middleware component.
 
-Any middleware updating the default values according to the first category should also update the arity. 
+Any middleware updating the default values from statically defined sources should also update the arity. 
 Use `argument.Arity = ArgumentArity.Default(argument)` to calculate a new arity for the argument.
 
 ## Summary by definition type

--- a/docs/Arguments/argument-types.md
+++ b/docs/Arguments/argument-types.md
@@ -3,11 +3,24 @@
 Arguments can be defined with any type that...
 
 * is a primitive type: 
-* has a TypeConverter
+* has a [TypeConverter](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.typeconverter)
 * contains a string constructor
 * has a `public static Parse(string)` method or `public static Parse(string, {optional paremeters})`
   
 The constructor and static Parse method may contain additional optional parameters but must contain only a single required string parameter.
+
+``` c#
+
+public class Employee
+{
+    public Employee(string name) { }
+    public Employee(string name, string position = null) { }
+
+    public static Employee Parse(string name){ }
+    public static Employee Parse(string name, string position = null){ }
+}
+
+```
 
 Includes, but not limited to:
 

--- a/docs/ReleaseNotes/CommandDotNet.TestTools.md
+++ b/docs/ReleaseNotes/CommandDotNet.TestTools.md
@@ -1,5 +1,9 @@
 # CommandDotNet.TestTools
 
+## 3.1.3
+
+TrackingInvocation implements new IInvocation.IsInterceptor property
+
 ## 3.1.2
 
 Extracted `ITestConsole` interface from `TestConsole` to support the [Spectre extensions](../OtherFeatures/spectre.md)

--- a/docs/ReleaseNotes/CommandDotNet.md
+++ b/docs/ReleaseNotes/CommandDotNet.md
@@ -1,5 +1,14 @@
 # CommandDotNet
 
+## 5.0.0
+
+NRT support
+
+* this is a breaking change in behavior since these arguments were not previously considered nullable and so the Arity has changed to expect a minimum of 0 instead of 1
+* Using the UseArgumentPrompter will work more as expected now when using NRTs. They will no longer prompt the user.
+
+
+
 ## 4.3.0
 
 * add `[Named]` and `[Positional]` attributes which can be used in place of `[Option]` and `[Operand]` respectively.


### PR DESCRIPTION
* this is a breaking change in behavior since these
   arguments were not previously considered nullable
   and so the Arity has changed to expect a minimum
   of 0 instead of 1
* Using the UseArgumentPrompter will work more as
   expected now when using NRTs. They will no longer
   prompt the user.

IArgument updates

* added IsOptional and BooleanMode properties to help
   determine the Arity for an argument.
* IsOptional will be true for nullable and NRT types and
   for optional paramters.
* BooleanMode will only be set for boolean arguments

IInvocation updates

* added IsInterceptor property to distinguish between
   command and interceptor invocations