### PR TITLE
Correcting typos of `application`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ public class Program
 <sup><a href='https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.DocExamples/GettingStarted/Getting_Started_100_Calculator.cs#L11-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-getting-started-100-calculator' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-That's it. You now have an applciation with two commands. Let's see about how we can call it from command line.
+That's it. You now have an application with two commands. Let's see about how we can call it from command line.
 
 Assuming our application's name is `calculator.dll`, let's run this app from command line using dotnet.
 First we'll check out the auto-generated help.

--- a/docs/GettingStarted/getting-started-100-calculator.md
+++ b/docs/GettingStarted/getting-started-100-calculator.md
@@ -28,7 +28,7 @@ public class Program
 <sup><a href='https://github.com/bilal-fazlani/commanddotnet/blob/master/CommandDotNet.DocExamples/GettingStarted/Getting_Started_100_Calculator.cs#L11-L28' title='Snippet source file'>snippet source</a> | <a href='#snippet-getting-started-100-calculator' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-That's it. You now have an applciation with two commands. Let's see about how we can call it from command line.
+That's it. You now have an application with two commands. Let's see about how we can call it from command line.
 
 Assuming our application's name is `calculator.dll`, let's run this app from command line using dotnet.
 First we'll check out the auto-generated help.


### PR DESCRIPTION
Correcting `application` to `application` in `README.md` and `getting-started-100-calculator.md`.