### PR TITLE
verify OnRunCompleted waits for pipeline to complete

### DIFF
--- a/CommandDotNet.Tests/FeatureTests/OnRunCompletedTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/OnRunCompletedTests.cs
@@ -32,9 +32,9 @@ namespace CommandDotNet.Tests.FeatureTests
         {
             public static bool Executed { get; set; }
 
-            public void Do()
+            public async Task Do()
             {
-                Task.Delay(1000);
+                await Task.Delay(1000);
                 Executed = true;
             }
         }

--- a/CommandDotNet.Tests/FeatureTests/OnRunCompletedTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/OnRunCompletedTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,16 +19,24 @@ namespace CommandDotNet.Tests.FeatureTests
             new AppRunner<App>()
                 .Configure(b => b.OnRunCompleted += args =>
                 {
+                    // ensure OnRunCompleted waits for the pipeline to complete
+                    App.Executed.Should().BeTrue();
                     wasCalled = true;
                 })
-                .RunInMem("");
+                .RunInMem("Do");
 
             wasCalled.Should().BeTrue();
         }
 
         private class App
         {
-            public void Do() { }
+            public static bool Executed { get; set; }
+
+            public void Do()
+            {
+                Task.Delay(1000);
+                Executed = true;
+            }
         }
     }
 }

--- a/CommandDotNet/AppRunner.cs
+++ b/CommandDotNet/AppRunner.cs
@@ -156,9 +156,9 @@ namespace CommandDotNet
             //            (when ctor options are moved to a middleware method, invocation context should be populated in Parse stage)
         }
 
-        private Task<int> OnRunCompleted(CommandContext context, ExecutionDelegate next)
+        private async Task<int> OnRunCompleted(CommandContext context, ExecutionDelegate next)
         {
-            var result = next(context);
+            var result = await next(context);
             context.AppConfig.OnRunCompleted?.Invoke(new OnRunCompletedEventArgs(context));
             return result;
         }


### PR DESCRIPTION
an attempt to verify #488. 

@Sibusten can you post a failing test or point to a repo where this is failing?  I updated a test that seems to verify OnRunCompleted is called only after the pipeline is executed.  I might be missing something.