### PR TITLE
Add DescriptionMethodAttribute for dynamic help text generation…

### DIFF
--- a/CommandDotNet.DocExamples/Arguments/Description/DescriptionMethod.cs
+++ b/CommandDotNet.DocExamples/Arguments/Description/DescriptionMethod.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace CommandDotNet.DocExamples.Arguments.Description;
+
+public class DescriptionMethodExamples
+{
+    public void Deploy(
+        [Option('t', "targets")]
+        [DescriptionMethod(nameof(GetTargetsDescription))]
+        string[] targets,
+
+        [Option('e', "environment")]
+        [DescriptionMethod(nameof(GetEnvironmentsDescription))]
+        string environment = "dev")
+    {
+        Console.WriteLine($"Deploying {string.Join(", ", targets)} to {environment}");
+    }
+
+    private static string GetTargetsDescription()
+    {
+        // Dynamic discovery of available targets
+        var availableTargets = new[] { "app", "database", "cache", "notifications" };
+        return $"Available targets: {string.Join(", ", availableTargets)}";
+    }
+
+    private static string GetEnvironmentsDescription()
+    {
+        // Could read from config, environment variables, etc.
+        var environments = new[] { "dev", "staging", "prod" };
+        return $"Available environments: {string.Join(", ", environments)}";
+    }
+    
+}

--- a/CommandDotNet.DocExamples/Arguments/Description/DescriptionMethodTests.cs
+++ b/CommandDotNet.DocExamples/Arguments/Description/DescriptionMethodTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using CommandDotNet.TestTools;
+using CommandDotNet.TestTools.Scenarios;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CommandDotNet.DocExamples.Arguments.Description;
+
+public class DescriptionMethodTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public DescriptionMethodTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // begin-snippet: description_method_test_basic
+    [Fact]
+    public void Deploy_Help_ShowsDynamicDescriptions()
+    {
+        var result = new AppRunner<DescriptionMethodExamples>()
+            .RunInMem("deploy --help", _output);
+
+        result.ExitCode.Should().Be(0);
+        result.Console.Out.Should().Contain("Available targets: app, database, cache, notifications");
+        result.Console.Out.Should().Contain("Available environments: dev, staging, prod");
+    }
+    // end-snippet
+
+    // begin-snippet: description_method_test_dynamic
+    [Fact]
+    public void ProcessFiles_Help_ShowsCurrentDirectoryInfo()
+    {
+        var result = new AppRunner<DescriptionMethodExamples>()
+            .RunInMem("process-files --help", _output);
+
+        result.ExitCode.Should().Be(0);
+        result.Console.Out.Should().Contain("Directory to process. Current:");
+        result.Console.Out.Should().Contain("Supported: json, xml, yaml, csv");
+        result.Console.Out.Should().Contain("Last updated:");
+    }
+    // end-snippet
+
+    // begin-snippet: description_method_test_execution
+    [Fact]
+    public void Deploy_ExecutesNormally()
+    {
+        var result = new AppRunner<DescriptionMethodExamples>()
+            .RunInMem("deploy --targets app,database --environment staging", _output);
+
+        result.ExitCode.Should().Be(0);
+        result.Console.Out.Should().Contain("Deploying app, database to staging");
+    }
+    // end-snippet
+
+    // begin-snippet: description_method_test_real_world
+    [Fact]
+    public void SyncData_Help_ShowsDynamicOptions()
+    {
+        var result = new AppRunner<DescriptionMethodExamples>()
+            .RunInMem("sync-data --help", _output);
+
+        result.ExitCode.Should().Be(0);
+        result.Console.Out.Should().Contain("Available: production, staging, backup, archive");
+        result.Console.Out.Should().Contain("Available: local, s3-bucket, azure-blob, gcp-storage");
+        result.Console.Out.Should().Contain("Available: full, incremental, differential");
+        result.Console.Out.Should().Contain("Last sync:");
+    }
+    // end-snippet
+
+    // This test demonstrates the validation error when both Description and DescriptionMethod are used
+    [Fact]
+    public void ProcessItems_WithBothDescriptionAndMethod_ThrowsValidationError()
+    {
+        var exception = Assert.Throws<InvalidConfigurationException>(() =>
+        {
+            new AppRunner<DescriptionMethodExamples>()
+                .RunInMem("process-items --help", _output);
+        });
+
+        exception.Message.Should().Contain("Multiple description properties were set");
+        exception.Message.Should().Contain("Description, DescriptionMethod");
+    }
+}

--- a/CommandDotNet.Example/Examples.cs
+++ b/CommandDotNet.Example/Examples.cs
@@ -1,4 +1,5 @@
-﻿using CommandDotNet.Example.Commands;
+﻿using System;
+using CommandDotNet.Example.Commands;
 using Git = CommandDotNet.Example.Commands.Git;
 
 namespace CommandDotNet.Example;
@@ -42,7 +43,7 @@ internal class Examples
     public Git Git { get; set; } = null!;
 
     [Subcommand]
-    public Math Math { get; set; } = null!;
+    public Commands.Math Math { get; set; } = null!;
 
     [Subcommand]
     public Models Models { get; set; } = null!;
@@ -55,4 +56,30 @@ internal class Examples
 
     [Subcommand]
     public Commands.Prompts Prompts { get; set; } = null!;
+
+    // Example demonstrating the new DescriptionMethod feature
+    [Command(Description = "Deploy services with dynamic target discovery")]
+    public void Deploy(
+        [Option('t', "targets"), DescriptionMethod(nameof(GetAvailableTargets))]
+        string[] targets,
+        
+        [Option('e', "environment"), DescriptionMethod(nameof(GetAvailableEnvironments))]
+        string environment = "dev")
+    {
+        Console.WriteLine($"Deploying targets: {string.Join(", ", targets)} to {environment}");
+    }
+
+    // Dynamic description methods
+    private static string GetAvailableTargets()
+    {
+        var availableTargets = new[] { "app", "database", "cache", "notifications" };
+        return $"Available targets: {string.Join(", ", availableTargets)}";
+    }
+
+    private static string GetAvailableEnvironments()
+    {
+        // Dynamic environment discovery
+        var environments = new[] { "dev", "staging", "prod" };
+        return $"Available environments: {string.Join(", ", environments)}. Current time: {DateTime.Now:HH:mm:ss}";
+    }
 }

--- a/CommandDotNet.Tests/FeatureTests/Help/ArgumentAttributesHelpTests.cs
+++ b/CommandDotNet.Tests/FeatureTests/Help/ArgumentAttributesHelpTests.cs
@@ -116,8 +116,8 @@ x_descr2"
             Then =
             {
                 ExitCode = 1,
-                Output = "CommandDotNet.InvalidConfigurationException: Both Description and DescriptionLines were set for " +
-                         "CommandDotNet.Tests.FeatureTests.Help.ArgumentAttributesHelpTests+OptionDupeDescriptions.Do.my_option. Only one can be set."
+                Output = "CommandDotNet.InvalidConfigurationException: Multiple description properties were set for " +
+                         "CommandDotNet.Tests.FeatureTests.Help.ArgumentAttributesHelpTests+OptionDupeDescriptions.Do.my_option: Description, DescriptionLines. Only one can be set."
             }
         });
     }
@@ -131,10 +131,84 @@ x_descr2"
             Then =
             {
                 ExitCode = 1,
-                Output = "CommandDotNet.InvalidConfigurationException: Both Description and DescriptionLines were set for " +
-                         "CommandDotNet.Tests.FeatureTests.Help.ArgumentAttributesHelpTests+OperandDupeDescriptions.Do.my_operand. Only one can be set."
+                Output = "CommandDotNet.InvalidConfigurationException: Multiple description properties were set for " +
+                         "CommandDotNet.Tests.FeatureTests.Help.ArgumentAttributesHelpTests+OperandDupeDescriptions.Do.my_operand: Description, DescriptionLines. Only one can be set."
             }
         });
+    }
+
+    [Fact]
+    public void Errors_when_description_and_description_method_are_both_used_in_OptionAttribute()
+    {
+        new AppRunner<OptionDupeDescriptionAndMethod>().Verify(new Scenario
+        {
+            When = { Args = "" },
+            Then =
+            {
+                ExitCode = 1,
+                Output = "CommandDotNet.InvalidConfigurationException: Multiple description properties were set for " +
+                         "CommandDotNet.Tests.FeatureTests.Help.ArgumentAttributesHelpTests+OptionDupeDescriptionAndMethod.Do.my_option: Description, DescriptionMethod. Only one can be set."
+            }
+        });
+    }
+
+    [Fact]
+    public void Errors_when_description_lines_and_description_method_are_both_used_in_OperandAttribute()
+    {
+        new AppRunner<OperandDupeDescriptionLinesAndMethod>().Verify(new Scenario
+        {
+            When = { Args = "" },
+            Then =
+            {
+                ExitCode = 1,
+                Output = "CommandDotNet.InvalidConfigurationException: Multiple description properties were set for " +
+                         "CommandDotNet.Tests.FeatureTests.Help.ArgumentAttributesHelpTests+OperandDupeDescriptionLinesAndMethod.Do.my_operand: DescriptionLines, DescriptionMethod. Only one can be set."
+            }
+        });
+    }
+
+    [Fact]
+    public void DescriptionMethod_Works_For_Option()
+    {
+        new AppRunner<AppWithDescriptionMethod>(TestAppSettings.DetailedHelp)
+            .Verify(
+                new Scenario
+                {
+                    When = {Args = "DoWithOption -h"},
+                    Then =
+                    {
+                        Output = @"Usage: testhost.dll DoWithOption [options] <arg>
+
+Arguments:
+
+  arg  <TEXT>
+
+Options:
+
+  -t | --targets  <TEXT>
+  The targets to sync, e.g. schemas, workflows, app, rules."
+                    }
+                });
+    }
+
+    [Fact]
+    public void DescriptionMethod_Works_For_Operand()
+    {
+        new AppRunner<AppWithDescriptionMethod>(TestAppSettings.DetailedHelp)
+            .Verify(
+                new Scenario
+                {
+                    When = {Args = "DoWithOperand -h"},
+                    Then =
+                    {
+                        Output = @"Usage: testhost.dll DoWithOperand <operand>
+
+Arguments:
+
+  operand  <TEXT>
+  Available targets: target1, target2, target3"
+                    }
+                });
     }
 
     private class App
@@ -152,8 +226,43 @@ x_descr2"
     {
         public void Do([Option(Description = "", DescriptionLines = [""])] string my_option) { }
     }
+    
     private class OperandDupeDescriptions
     {
         public void Do([Operand(Description = "", DescriptionLines = [""])] string my_operand) { }
+    }
+    
+    private class OptionDupeDescriptionAndMethod
+    {
+        public void Do([Option(Description = "some description"), DescriptionMethod(nameof(GetTargetDescription))] string my_option) { }
+        
+        private static string GetTargetDescription() => "Method description";
+    }
+    
+    private class OperandDupeDescriptionLinesAndMethod
+    {
+        public void Do([Operand(DescriptionLines = ["line1", "line2"]), DescriptionMethod(nameof(GetTargetDescription))] string my_operand) { }
+        
+        private static string GetTargetDescription() => "Method description";
+    }
+    
+    private class AppWithDescriptionMethod
+    {
+        public void DoWithOption(
+            [Option('t', "targets"), DescriptionMethod(nameof(DescribeTargets))] string targets,
+            string arg) { }
+            
+        public void DoWithOperand(
+            [Operand, DescriptionMethod(nameof(DescribeOperandTargets))] string operand) { }
+        
+        private static string DescribeTargets()
+        {
+            return "The targets to sync, e.g. schemas, workflows, app, rules.";
+        }
+        
+        private static string DescribeOperandTargets()
+        {
+            return "Available targets: target1, target2, target3";
+        }
     }
 }

--- a/CommandDotNet/DescriptionMethodAttribute.cs
+++ b/CommandDotNet/DescriptionMethodAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using JetBrains.Annotations;
+
+namespace CommandDotNet;
+
+[PublicAPI]
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+public class DescriptionMethodAttribute : Attribute
+{
+
+    public string MethodName { get; }
+
+    public DescriptionMethodAttribute(string methodName)
+    {
+        MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+    }
+}

--- a/CommandDotNet/Help/HelpTextProvider.cs
+++ b/CommandDotNet/Help/HelpTextProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using CommandDotNet.Extensions;
 using JetBrains.Annotations;
@@ -206,8 +207,77 @@ public class HelpTextProvider : IHelpProvider
     protected virtual string? ArgumentTypeName<T>(T argument) where T : IArgument => 
         argument.TypeInfo.DisplayName.UnlessNullOrWhitespace(n => $"<{n.ToUpperInvariant()}>");
 
-    protected virtual string? ArgumentDescription<T>(T argument) where T : IArgument => 
-        argument.Description.UnlessNullOrWhitespace(_localize);
+    protected virtual string? ArgumentDescription<T>(T argument) where T : IArgument
+    {
+        var description = argument.Description;
+        
+        // Check if this is a method-based description
+        if (description != null && description.StartsWith("__DESCRIPTION_METHOD__") && description.EndsWith("__"))
+        {
+            var methodName = description.Substring("__DESCRIPTION_METHOD__".Length, 
+                description.Length - "__DESCRIPTION_METHOD__".Length - 2);
+            description = ResolveDescriptionMethod(argument, methodName);
+        }
+        
+        return description.UnlessNullOrWhitespace(_localize);
+    }
+    
+    /// <summary>
+    /// Resolves a description method by calling the specified static method.
+    /// </summary>
+    /// <param name="argument">The argument that has the description method attribute</param>
+    /// <param name="methodName">The name of the method to call</param>
+    /// <returns>The description returned by the method, or null if the method cannot be resolved</returns>
+    protected virtual string? ResolveDescriptionMethod<T>(T argument, string methodName) where T : IArgument
+    {
+        try
+        {
+            // Get the declaring type from the argument's custom attributes
+            Type? declaringType = null;
+            
+            if (argument.CustomAttributes is ParameterInfo paramInfo)
+            {
+                declaringType = paramInfo.Member.DeclaringType;
+            }
+            else if (argument.CustomAttributes is PropertyInfo propInfo)
+            {
+                declaringType = propInfo.DeclaringType;
+            }
+            
+            if (declaringType == null)
+            {
+                return $"Error: Could not determine declaring type for method '{methodName}'";
+            }
+            
+            // Find the method
+            var method = declaringType.GetMethod(methodName, 
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                null, Type.EmptyTypes, null);
+                
+            if (method == null)
+            {
+                return $"Error: Method '{methodName}' not found in type '{declaringType.Name}'";
+            }
+            
+            if (!method.IsStatic)
+            {
+                return $"Error: Method '{methodName}' must be static";
+            }
+            
+            if (method.ReturnType != typeof(string))
+            {
+                return $"Error: Method '{methodName}' must return string";
+            }
+            
+            // Invoke the method
+            var result = method.Invoke(null, null) as string;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return $"Error calling method '{methodName}': {ex.Message}";
+        }
+    }
 
     protected virtual string ArgumentArity<T>(T argument) where T : IArgument => 
         argument.Arity.AllowsMany() ? $" ({Resources.A.Help_Multiple})" : "";


### PR DESCRIPTION
# Add DescriptionMethodAttribute for dynamic help text generation

Resolved #472

## Summary

This PR implements a new `DescriptionMethodAttribute` that allows developers to specify methods for generating dynamic help descriptions at runtime, rather than being limited to static descriptions.

